### PR TITLE
EIP1271 smart contract wallet support

### DIFF
--- a/src/sdk/NftSwap.ts
+++ b/src/sdk/NftSwap.ts
@@ -12,30 +12,23 @@ import {
   TransactionOverrides,
   PayableOverrides,
   hashOrder,
+  SigningOptions,
+  getForwarderAddress,
 } from './pure';
 import {
   EIP712_TYPES,
-  EipDomain,
   getEipDomain,
   SupportedTokenTypes,
   TypedData,
 } from '../utils/order';
-import { UnexpectedAssetTypeError } from './error';
 import type {
   BaseProvider,
-  JsonRpcSigner,
   TransactionReceipt,
 } from '@ethersproject/providers';
 import type { ContractTransaction } from '@ethersproject/contracts';
-import type { InterallySupportedAssetFormat } from './pure';
-import type {
-  UserFacingERC1155AssetDataSerializedNormalizedSingle,
-  UserFacingERC20AssetDataSerialized,
-  UserFacingERC721AssetDataSerialized,
-} from '../utils/order';
 import { normalizeOrder as _normalizeOrder } from '../utils/order';
-import { AssetProxyId, Order, SignedOrder } from './types';
-import { Signer, TypedDataSigner } from '@ethersproject/abstract-signer';
+import { Order, SignedOrder } from './types';
+import { Signer } from '@ethersproject/abstract-signer';
 import { ExchangeContract, ExchangeContract__factory } from '../contracts';
 import {
   convertAssetsToInternalFormat,
@@ -43,18 +36,20 @@ import {
   SwappableAsset,
 } from '../utils/asset-data';
 
-interface NftSwapConfig {
+export interface NftSwapConfig {
   exchangeContractAddress?: string;
   erc20ProxyContractAddress?: string;
   erc721ProxyContractAddress?: string;
   erc1155ProxyContractAddress?: string;
+  forwarderContractAddress?: string;
 }
 
-interface INftSwap {
+export interface INftSwap {
   signOrder: (
     order: Order,
     signerAddress: string,
-    signer: Signer
+    signer: Signer,
+    signingOptions?: Partial<SigningOptions>
   ) => Promise<SignedOrder>;
   buildOrder: (
     makerAssets: Array<SwappableAsset>,
@@ -129,6 +124,7 @@ class NftSwap implements INftSwap {
   public erc20ProxyContractAddress: string;
   public erc720ProxyContractAddress: string;
   public erc1155ProxyContractAddress: string;
+  public forwarderContractAddress: string | null;
 
   constructor(
     provider: BaseProvider,
@@ -160,6 +156,10 @@ class NftSwap implements INftSwap {
     this.erc1155ProxyContractAddress =
       additionalConfig?.erc1155ProxyContractAddress ??
       getProxyAddressForErcType(SupportedTokenTypes.ERC1155, chainId);
+    this.forwarderContractAddress =
+      additionalConfig?.forwarderContractAddress ??
+      getForwarderAddress(chainId) ??
+      null;
 
     // Initialize Exchange contract so we can interact with it easily.
     this.exchangeContract = ExchangeContract__factory.connect(
@@ -195,8 +195,6 @@ class NftSwap implements INftSwap {
       this.exchangeContract.address
     );
   };
-
-  public signOrderWithHash = async () => {};
 
   public buildOrder = (
     makerAssets: SwappableAsset[],
@@ -292,12 +290,12 @@ class NftSwap implements INftSwap {
     );
   };
 
-  public normalizeOrder = (order: Order) => {
+  public normalizeOrder = (order: Order): Order => {
     const normalizedOrder = _normalizeOrder(order);
     return normalizedOrder as Order;
   };
 
-  public normalizeSignedOrder = (order: SignedOrder) => {
+  public normalizeSignedOrder = (order: SignedOrder): SignedOrder => {
     const normalizedOrder = _normalizeOrder(order);
     return normalizedOrder as SignedOrder;
   };

--- a/src/sdk/NftSwap.ts
+++ b/src/sdk/NftSwap.ts
@@ -189,7 +189,8 @@ class NftSwap implements INftSwap {
     return _signOrder(
       order,
       addressOfWalletSigningOrder,
-      signerToUser as any,
+      signerToUser,
+      this.provider,
       this.chainId,
       this.exchangeContract.address
     );
@@ -284,12 +285,11 @@ class NftSwap implements INftSwap {
     fillOverrides?: Partial<FillOrderOverrides>,
     transactionOverrides: Partial<PayableOverrides> = {}
   ) => {
-    const tx = await _sendSignedOrderToEthereum(
+    return _sendSignedOrderToEthereum(
       signedOrder,
       fillOverrides?.exchangeContract ?? this.exchangeContract,
       transactionOverrides
     );
-    return tx;
   };
 
   public normalizeOrder = (order: Order) => {

--- a/src/sdk/pure.ts
+++ b/src/sdk/pure.ts
@@ -32,12 +32,19 @@ import {
   ExchangeContract,
 } from '../contracts';
 import { UnexpectedAssetTypeError, UnsupportedChainId } from './error';
-import type { AddressesForChain, Order, SignedOrder } from './types';
+import type {
+  AddressesForChain,
+  Order,
+  SignatureType,
+  SignedOrder,
+} from './types';
 import addresses from '../addresses.json';
 import { encodeTypedDataHash, TypedData } from '../utils/typed-data';
 import { Interface } from '@ethersproject/abi';
 import { EIP1271ZeroExDataAbi } from '../utils/eip1271';
 import { Signer } from 'ethers';
+import { TypedDataSigner } from '@ethersproject/abstract-signer';
+import invariant from 'tiny-invariant';
 
 export enum AssetProxyId {
   ERC20 = '0xf47261b0',
@@ -79,68 +86,159 @@ export const hashOrder = (
 export type InterallySupportedAssetFormat =
   UserFacingSerializedSingleAssetDataTypes;
 
+export type AvailableSignatureTypes = 'eoa' | 'eip1271';
+
+export interface SigningOptions {
+  signatureType: AvailableSignatureTypes; // | 'autodetect' ? and remove autodetectSignatureType maybe?
+  autodetectSignatureType: boolean;
+}
+
+const signOrderWithEip1271 = async (
+  order: Order,
+  signer: Signer,
+  chainId: number,
+  exchangeContractAddress: string
+) => {
+  const domain = getEipDomain(chainId, exchangeContractAddress);
+  const types = EIP712_TYPES;
+  const value = order;
+
+  const typedData: TypedData = {
+    domain,
+    types,
+    message: value,
+  };
+
+  const orderHash = encodeTypedDataHash(typedData);
+
+  const msg = new Interface(EIP1271ZeroExDataAbi).encodeFunctionData(
+    'OrderWithHash',
+    [order, orderHash]
+  );
+
+  const rawSignatureFromContractWallet = await signer.signMessage(
+    arrayify(msg)
+  );
+
+  return rawSignatureFromContractWallet;
+};
+
+export const signOrderWithEoaWallet = async (
+  order: Order,
+  signer: TypedDataSigner,
+  chainId: number,
+  exchangeContractAddress: string
+) => {
+  const domain = getEipDomain(chainId, exchangeContractAddress);
+  const types = EIP712_TYPES;
+  const value = order;
+
+  const rawSignatureFromEoaWallet = await signer._signTypedData(
+    domain,
+    types,
+    value
+  );
+
+  return rawSignatureFromEoaWallet;
+};
+
+const checkIfContractWallet = async (
+  provider: Provider,
+  walletAddress: string
+): Promise<boolean> => {
+  let isContractWallet: boolean = false;
+  if (provider.getCode) {
+    let walletCode = await provider.getCode(walletAddress);
+    // Wallet Code returns '0x' if no contract address is associated with
+    // Note: Lazy loaded contract wallets will show 0x initially, so we fall back to feature detection
+    if (walletCode && walletCode != '0x') {
+      isContractWallet = true;
+    }
+  }
+  let isSequence = !!(provider as any)._isSequenceProvider;
+  if (isSequence) {
+    isContractWallet = true;
+  }
+  // Walletconnect hides the real provider in the provider (yo dawg)
+  let providerToUse = (provider as any).provider;
+  if (providerToUse?.isWalletConnect) {
+    const isSequenceViaWalletConnect = !!(
+      (providerToUse as any).connector?._peerMeta?.description === 'Sequence'
+    );
+    if (isSequenceViaWalletConnect) {
+      isContractWallet = true;
+    }
+  }
+
+  return isContractWallet;
+};
+
 export const signOrder = async (
   order: Order,
   signerAddress: string,
   signer: Signer,
   provider: Provider,
   chainId: number,
-  exchangeContractAddress: string
+  exchangeContractAddress: string,
+  signingOptions?: Partial<SigningOptions>
 ): Promise<SignedOrder> => {
   try {
-    // Let's try to determine if the signer is a contract wallet or not.
-    // If it is, we'll try EIP-1271, otherwise we'll do a normal sign
-    let isContractWallet = false;
+    let method: AvailableSignatureTypes = 'eoa';
+    // If we have any specific signature type overrides, prefer those
+    if (signingOptions?.signatureType === 'eip1271') {
+      method = 'eip1271';
+    } else if (signingOptions?.signatureType === 'eoa') {
+      method = 'eoa';
+    } else {
+      // Try to detect...
+      if (signingOptions?.autodetectSignatureType === false) {
+        method = 'eoa';
+      } else {
+        // If we made it here, consumer has no preferred signing method,
+        // let's try feature detection to automagically pick a signature type
+        // By default we fallback to EOA signing if we can't figure it out.
 
-    let walletCode = await provider.getCode(signerAddress);
-    // Wallet Code returns '0x' if no contract address is associated with
-    // Note: Lazy loaded contract wallets will show 0x initially, so we fall back to feature detection
-    if (walletCode && walletCode != '0x') {
-      isContractWallet = true;
-    }
-    let isSequence = !!(provider as any)._isSequenceProvider;
-    if (isSequence) {
-      isContractWallet = true;
-    }
-    // Walletconnect hides the real provider in the provider (yo dawg)
-    let providerToUse = (provider as any).provider;
-    if (providerToUse?.isWalletConnect) {
-      const isSequenceViaWalletConnect = !!(
-        (providerToUse as any).connector?._peerMeta?.description === 'Sequence'
-      );
-      if (isSequenceViaWalletConnect) {
-        isContractWallet = true;
+        // Let's try to determine if the signer is a contract wallet or not.
+        // If it is, we'll try EIP-1271, otherwise we'll do a normal sign
+        const isContractWallet = await checkIfContractWallet(
+          provider,
+          signerAddress
+        );
+        if (isContractWallet) {
+          method = 'eip1271';
+        } else {
+          method = 'eoa';
+        }
       }
     }
-
-    const domain = getEipDomain(chainId, exchangeContractAddress);
-    const types = EIP712_TYPES;
-    const value = order;
-
-    const typedData: TypedData = {
-      domain,
-      types,
-      message: value,
-    };
-
-    const orderHash = encodeTypedDataHash(typedData);
-
-    const msg = new Interface(EIP1271ZeroExDataAbi).encodeFunctionData(
-      'OrderWithHash',
-      [order, orderHash]
-    );
-
-    const rawSignatureFromContractWallet = await signer.signMessage(
-      arrayify(msg)
-    );
-
-    console.log(rawSignatureFromContractWallet, rawSignatureFromContractWallet);
-
-    // const rawSignatureFromEoaWallet = await signer._signTypedData(domain, types, value);
+    let signature: string;
+    switch (method) {
+      case 'eoa':
+        const rawEip712Signature = await signOrderWithEoaWallet(
+          order,
+          signer as unknown as TypedDataSigner,
+          chainId,
+          exchangeContractAddress
+        );
+        signature = prepareOrderSignatureFromEoaWallet(rawEip712Signature);
+        break;
+      case 'eip1271':
+        const rawEip1271Signature = (signature = await signOrderWithEip1271(
+          order,
+          signer,
+          chainId,
+          exchangeContractAddress
+        ));
+        signature =
+          prepareOrderSignatureFromContractWallet(rawEip1271Signature);
+        break;
+      default:
+        throw new Error(`Unknown signature method chosen: ${method}`);
+    }
 
     const signedOrder: SignedOrder = {
       ...order,
-      signature: rawSignatureFromContractWallet,
+      signature,
     };
 
     return signedOrder;
@@ -150,14 +248,34 @@ export const signOrder = async (
   }
 };
 
-export const prepareOrderSignature = (rawSignature: string) => {
+export const prepareOrderSignature = (
+  rawSignature: string,
+  method?: AvailableSignatureTypes
+) => {
+  let preferredMethod = method ?? 'eoa';
+  try {
+    return prepareOrderSignatureFromEoaWallet(rawSignature);
+  } catch (e) {
+    console.log('prepareOrderSignature:Errror preparing order signature', e);
+    console.log('Attempting to decode contract wallet signature');
+    try {
+      return prepareOrderSignatureFromContractWallet(rawSignature);
+    } catch (e) {
+      throw e;
+    }
+  }
+};
+
+export const prepareOrderSignatureFromEoaWallet = (rawSignature: string) => {
   // Append the signature type (eg. "0x02" for EIP712 signatures)
   // at the end of the signature since this is what 0x expects
   const signature = splitSignature(rawSignature);
   return hexConcat([hexlify(signature.v), signature.r, signature.s, '0x02']);
 };
 
-export const prepareOrderSignatureContractWallet = (rawSignature: string) => {
+export const prepareOrderSignatureFromContractWallet = (
+  rawSignature: string
+) => {
   // Append the signature type (eg. "0x07" for EIP712 signatures)
   // at the end of the signature since this is what 0x expects
   // See: https://github.com/0xProject/ZEIPs/issues/33
@@ -227,11 +345,23 @@ export const sendSignedOrderToEthereum = async (
   exchangeContract: ExchangeContract,
   overrides?: PayableOverrides
 ): Promise<ContractTransaction> => {
+  // const gas = await exchangeContract.estimateGas.fillOrder(
+  //   normalizeOrder(signedOrder),
+  //   signedOrder.takerAssetAmount,
+  //   signedOrder.signature,
+  //   // prepareOrderSignature(signedOrder.signature), // EOA signatures...
+  //   // prepareOrderSignatureContractWallet(signedOrder.signature), // Contract wallet signatures.
+  //   // prepareOrderSignature(signedOrder.signature), // Contract wallet signatures.
+  //   overrides
+  // )
+  // console.log('sendSignedOrderToEthereum:gas', gas.toString())
   return exchangeContract.fillOrder(
     normalizeOrder(signedOrder),
     signedOrder.takerAssetAmount,
+    signedOrder.signature,
     // prepareOrderSignature(signedOrder.signature), // EOA signatures...
-    prepareOrderSignatureContractWallet(signedOrder.signature), // Contract wallet signatures.
+    // prepareOrderSignatureContractWallet(signedOrder.signature), // Contract wallet signatures.
+    // prepareOrderSignature(signedOrder.signature), // Contract wallet signatures.
     overrides
   );
 };
@@ -410,6 +540,14 @@ export const getProxyAddressForErcType = (
     default:
       throw new UnexpectedAssetTypeError(assetType);
   }
+};
+
+export const getForwarderAddress = (chainId: number) => {
+  const zeroExAddresses = getZeroExAddressesForChain(chainId);
+  if (!zeroExAddresses) {
+    throw new UnsupportedChainId(chainId);
+  }
+  return zeroExAddresses.forwarder;
 };
 
 // export const loadApprovalStatusAll = async (assets: Array<InterallySupportedAsset>) => {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -224,4 +224,5 @@ export interface AddressesForChain {
   erc721Proxy: string;
   multiAssetProxy: string;
   erc1155Proxy: string;
+  forwarder: string;
 }

--- a/src/utils/eip1271.ts
+++ b/src/utils/eip1271.ts
@@ -1,0 +1,92 @@
+export const EIP1271ZeroExDataAbi = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'makerAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'takerAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'feeRecipientAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'senderAddress',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'makerAssetAmount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'takerAssetAmount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'makerFee',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'takerFee',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'expirationTimeSeconds',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'salt',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes',
+            name: 'makerAssetData',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'takerAssetData',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'makerFeeAssetData',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'takerFeeAssetData',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct IEIP1271Data.Order',
+        name: 'order',
+        type: 'tuple',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'orderHash',
+        type: 'bytes32',
+      },
+    ],
+    name: 'OrderWithHash',
+    outputs: [],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+];

--- a/src/utils/typed-data.ts
+++ b/src/utils/typed-data.ts
@@ -1,0 +1,38 @@
+import {
+  TypedDataDomain,
+  TypedDataField,
+} from '@ethersproject/abstract-signer';
+import { arrayify } from '@ethersproject/bytes';
+import { _TypedDataEncoder } from '@ethersproject/hash';
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
+
+export interface TypedData {
+  domain: TypedDataDomain;
+  types: Record<string, Array<TypedDataField>>;
+  message: Record<string, any>;
+  primaryType?: string;
+}
+
+export type { TypedDataDomain, TypedDataField };
+
+export const encodeTypedDataHash = (typedData: TypedData): string => {
+  const types = { ...typedData.types };
+
+  // remove EIP712Domain key from types as ethers will auto-gen it in
+  // the hash encoder below
+  delete types['EIP712Domain'];
+
+  return _TypedDataEncoder.hash(typedData.domain, types, typedData.message);
+};
+
+export const encodeTypedDataDigest = (typedData: TypedData): Uint8Array => {
+  return arrayify(encodeTypedDataHash(typedData));
+};
+
+export const encodeMessageDigest = (message: string | Uint8Array) => {
+  if (typeof message === 'string') {
+    return arrayify(keccak256(toUtf8Bytes(message)));
+  } else {
+    return arrayify(keccak256(message));
+  }
+};

--- a/test/mumbai-swap.test.ts
+++ b/test/mumbai-swap.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { defaultAbiCoder, hexDataSlice, parseEther } from 'ethers/lib/utils';
+import { defaultAbiCoder, hexDataSlice, parseEther, hexDataLength } from 'ethers/lib/utils';
 import { NftSwap, SwappableAsset } from '../src';
 import { verifyOrderSignature } from '../src/sdk/pure';
 import { encodeErc20AssetData } from '../src/utils/asset-data';
@@ -95,15 +95,7 @@ describe('NFTSwap', () => {
       MAKER_WALLET_ADDRESS.toLowerCase()
     );
 
-    const isValidSignature = await verifyOrderSignature(
-      normalizedSignedOrder,
-      signedOrder.signature,
-      80001,
-      nftSwapperMaker.exchangeContract.address
-    );
-    expect(isValidSignature).toBe(true);
-
-    // Uncomment to actually fill order
+    // // Uncomment to actually fill order
     // const tx = await nftSwapperMaker.fillSignedOrder(signedOrder, undefined, {
     //   gasPrice,
     //   gasLimit: '500000',

--- a/test/signatures.test.ts
+++ b/test/signatures.test.ts
@@ -1,8 +1,7 @@
 import { ethers } from 'ethers';
-import { defaultAbiCoder, hexDataSlice, parseEther } from 'ethers/lib/utils';
+import { hexDataLength, hexDataSlice } from 'ethers/lib/utils';
 import { NftSwap, SwappableAsset } from '../src';
-import { verifyOrderSignature } from '../src/sdk/pure';
-import { encodeErc20AssetData } from '../src/utils/asset-data';
+import { signOrderWithEoaWallet, verifyOrderSignature } from '../src/sdk/pure';
 import { normalizeOrder } from '../src/utils/order';
 
 jest.setTimeout(60 * 1000);
@@ -18,11 +17,11 @@ const MAKER_PRIVATE_KEY =
 // const TAKER_PRIVATE_KEY =
 //   "a8d6d0643c732663bf5221f83df806a59ed54dbd9be02e226b1a11ff4de83de8";
 
-const USDC_TOKEN_ADDRESS_TESTNET = '0xeb8f08a975ab53e34d8a0330e0d34de942c95926';
-const DAI_TOKEN_ADDRESS_TESTNET = '0x6a9865ade2b6207daac49f8bcba9705deb0b0e6d';
+const USDC_TOKEN_ADDRESS_TESTNET = '0x9c3c9283d3e44854697cd22d3faa240cfb032889';
+const DAI_TOKEN_ADDRESS_TESTNET = '0x001b3b4d0f3714ca98ba10f6042daebf0b1b7b6f';
 
 const RPC_TESTNET =
-  'https://eth-rinkeby.alchemyapi.io/v2/is1WqyAFM1nNFFx2aCozhTep7IxHVNGo';
+  'https://polygon-mumbai.g.alchemy.com/v2/VMBpFqjMYv2w-MWnc9df92w3R2TpMvSG';
 
 const MAKER_WALLET = new ethers.Wallet(MAKER_PRIVATE_KEY);
 // const TAKER_WALLET = new ethers.Wallet(TAKER_PRIVATE_KEY);
@@ -32,25 +31,23 @@ const PROVIDER = new ethers.providers.StaticJsonRpcProvider(RPC_TESTNET);
 const MAKER_SIGNER = MAKER_WALLET.connect(PROVIDER);
 // const TAKER_PROVIDER = TAKER_WALLET.connect(PROVIDER);
 
-const nftSwapperMaker = new NftSwap(MAKER_SIGNER as any, MAKER_SIGNER, 4);
+const nftSwapperMaker = new NftSwap(MAKER_SIGNER as any, MAKER_SIGNER, 80001);
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
 const TAKER_ASSET: SwappableAsset = {
   type: 'ERC20',
   tokenAddress: USDC_TOKEN_ADDRESS_TESTNET,
-  amount: '100000', // 1 USDC
+  amount: '10000000000000000', // 1 WMATIC
 };
 const MAKER_ASSET: SwappableAsset = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
-  amount: '100000000000000000', // 1 DAI
+  amount: '10000000000000000', // 1 DAI
 };
 
 describe('NFTSwap', () => {
-  it('swaps 0.1 DAI and 0.1 USDC correctly', async () => {
+  it('eoa signatures correctly', async () => {
     // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
-
-    const gasPrice = (await PROVIDER.getGasPrice()).mul(2);
 
     const order = nftSwapperMaker.buildOrder(
       [MAKER_ASSET],
@@ -75,17 +72,26 @@ describe('NFTSwap', () => {
       MAKER_WALLET_ADDRESS.toLowerCase()
     );
 
-    // Uncomment to actually fill order
-    // const tx = await nftSwapperMaker.fillSignedOrder(signedOrder, undefined, {
-    //   gasPrice,
-    //   gasLimit: '500000',
-    //   // HACK(johnnrjj) - Rinkeby still has protocol fees, so we give it a little bit of ETH so its happy.
-    //   value: parseEther('0.01'),
-    // });
+    const rawSignature = await signOrderWithEoaWallet(
+      order,
+      nftSwapperMaker.signer as any,
+      nftSwapperMaker.chainId,
+      nftSwapperMaker.exchangeContractAddress
+    );
 
-    // const txReceipt = await tx.wait();
-    // expect(txReceipt.transactionHash).toBeTruthy();
-    // console.log(`Swapped on Rinkeby (txHAsh: ${txReceipt.transactionIndex})`);
+
+    const length = hexDataLength(signedOrder.signature);
+    const signatureType = hexDataSlice(signedOrder.signature, length - 1);
+    
+    expect(signatureType).toBe('0x02');
+
+    const isValidSignature = await verifyOrderSignature(
+      normalizedSignedOrder,
+      rawSignature,
+      80001,
+      nftSwapperMaker.exchangeContract.address
+    );
+    expect(isValidSignature).toBe(true);
   });
 });
 


### PR DESCRIPTION
Hardcoded to EIP1271. Need to finish adding signature type argument to signer function.

- [x] signOrder parameter for wallet signature type override (eoa or eip1271)
- [x] finish smart contract wallet feature detection
- [x] update tests