### PR TITLE
Adds additional order builder configuration (fees, custom maker/taker fee datas)

### DIFF
--- a/src/sdk/NftSwap.ts
+++ b/src/sdk/NftSwap.ts
@@ -120,11 +120,19 @@ export interface INftSwap {
  * All optional
  */
 export interface BuildOrderAdditionalConfig {
-  chainId?: number;
   takerAddress?: string;
-  expiration?: Date;
+  /**
+   * Date type or unix timestamp
+   */
+  expiration?: Date | number;
   exchangeAddress?: string;
+  chainId?: number;
   salt?: string;
+  feeRecipientAddress?: string,
+  makerFeeAssetData?: string,
+  takerFeeAssetData?: string,
+  makerFee?: string,
+  takerFee?: string,
 }
 
 export interface ApprovalOverrides {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -285,12 +285,16 @@ export type AvailableTradeableAssets =
   | Erc1155TradeableAsset;
 
 export interface AdditionalOrderConfig {
-  chainId: number;
-  makerAddress: string;
+  makerAddress: string; // only field required
+  chainId?: number;
   takerAddress?: string;
-  expiration?: Date;
+  expiration?: Date | number;
   exchangeAddress?: string;
   salt?: string;
+  feeRecipientAddress?: string,
+  makerFeeAssetData?: string,
+  takerFeeAssetData?: string,
+  makerFee?: string,
 }
 
 export interface ZeroExOrder {

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -56,11 +56,16 @@ export const generateOrderFromAssetDatas = (orderConfig: {
   takerAssetData: string;
   makerAssetAmount: BigNumber;
   takerAssetAmount: BigNumber;
-  chainId: number;
   exchangeAddress: string;
+  // Rest of params optional
   takerAddress?: string;
-  expiration?: Date;
+  expiration?: Date | number;
   salt?: string;
+  feeRecipientAddress?: string,
+  makerFeeAssetData?: string,
+  takerFeeAssetData?: string,
+  makerFee?: string,
+  takerFee?: string,
 }): Order => {
   const {
     makerAssetAmount,
@@ -71,6 +76,11 @@ export const generateOrderFromAssetDatas = (orderConfig: {
     takerAddress,
     expiration,
     salt,
+    feeRecipientAddress,
+    makerFeeAssetData,
+    takerFeeAssetData,
+    makerFee,
+    takerFee,
   } = orderConfig;
 
   const expirationTimeSeconds = expiration
@@ -87,12 +97,12 @@ export const generateOrderFromAssetDatas = (orderConfig: {
     expirationTimeSeconds: expirationTimeSeconds.toString(),
     // Stuff that doesn't really matter but is required
     senderAddress: NULL_ADDRESS,
-    feeRecipientAddress: TRADER_ADDRESS_IDENTIFIER,
+    feeRecipientAddress: feeRecipientAddress ?? TRADER_ADDRESS_IDENTIFIER,
     salt: salt ?? generateSaltHash(),
-    makerFeeAssetData: NULL_BYTES,
-    takerFeeAssetData: NULL_BYTES,
-    makerFee: ZERO_AMOUNT.toString(),
-    takerFee: ZERO_AMOUNT.toString(),
+    makerFeeAssetData: makerFeeAssetData ?? NULL_BYTES,
+    takerFeeAssetData: takerFeeAssetData ?? NULL_BYTES,
+    makerFee: makerFee ?? ZERO_AMOUNT.toString(),
+    takerFee: takerFee ?? ZERO_AMOUNT.toString(),
   };
 
   return order;

--- a/test/order-status.test.ts
+++ b/test/order-status.test.ts
@@ -82,10 +82,14 @@ describe('NFTSwap', () => {
       {
         // Fix dates and salt so we have reproducible tests
         expiration: new Date(3000, 10, 1),
+        feeRecipientAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeE'
       }
     );
 
     const normalizedOrder = normalizeOrder(order);
+
+    expect(normalizedOrder.feeRecipientAddress).toBe('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee');
+
 
     const orderInfo = await nftSwapperMaker.getOrderInfo(normalizedOrder);
 
@@ -94,7 +98,7 @@ describe('NFTSwap', () => {
     const signedOrder = await nftSwapperMaker.signOrder(
       normalizedOrder,
       MAKER_WALLET_ADDRESS,
-      MAKER_SIGNER
+      MAKER_SIGNER,
     );
 
     const normalizedSignedOrder = normalizeOrder(signedOrder);


### PR DESCRIPTION
Does not provide convenience methods around formatting `makerFeeAssetData` and `makerFee`, consumer will need to format that on their own as it is considered a more advanced order build path.