### PR TITLE
Adds Collection based orders

### DIFF
--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -18,6 +18,7 @@ import type {
   NftOrderV4,
   OrderStructOptionsCommon,
   OrderStructOptionsCommonStrict,
+  PropertyStruct,
 } from './types';
 import { BaseProvider } from '@ethersproject/providers';
 import { ApprovalStatus, TransactionOverrides } from '../common/types';
@@ -336,7 +337,7 @@ export const generateErc721Order = (
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,
     // Defaults not required...
-    erc721TokenProperties: [],
+    erc721TokenProperties: orderData.tokenProperties ?? [],
     fees: [],
     expiry: orderData.expiry
       ? getUnixTime(orderData.expiry)
@@ -345,7 +346,6 @@ export const generateErc721Order = (
     taker: orderData.taker ?? NULL_ADDRESS,
   };
 
-  console.log(erc721Order.nonce.toString());
   return erc721Order;
 };
 
@@ -363,7 +363,7 @@ export const generateErc1155Order = (
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,
     // Defaults not required...
-    erc1155TokenProperties: [],
+    erc1155TokenProperties: orderData.tokenProperties ?? [],
     fees: [],
     expiry: orderData.expiry
       ? getUnixTime(orderData.expiry)
@@ -386,4 +386,9 @@ type DirectionMap = {
 export const DIRECTION_MAPPING: DirectionMap = {
   [TradeDirection.BuyNFT]: 'buy',
   [TradeDirection.SellNFT]: 'sell',
+};
+
+export const CONTRACT_ORDER_VALIDATOR: PropertyStruct = {
+  propertyValidator: NULL_ADDRESS,
+  propertyData: [],
 };

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -52,6 +52,7 @@ export interface OrderStructOptionsCommon {
   // erc20Token: string;
   // erc20TokenAmount: BigNumberish;
   fees: FeeStruct[];
+  tokenProperties: PropertyStruct[];
 }
 
 export interface OrderStructOptionsCommonStrict {
@@ -63,6 +64,11 @@ export interface OrderStructOptionsCommonStrict {
   expiry?: Date | number;
   nonce?: BigNumberish;
   fees?: FeeStruct[];
+  tokenProperties?: PropertyStruct[];
+}
+
+interface OrderStructPropertyOptions {
+  tokenProperties: PropertyStruct[];
 }
 
 export interface Fee {
@@ -113,6 +119,7 @@ export interface ApprovalOverrides {
 export interface FillOrderOverrides {
   signer: Signer;
   exchangeContract: IZeroEx;
+  tokenIdToSellForCollectionOrder?: BigNumberish;
   /**
    * Fill order with native token if possible
    * e.g. If taker asset is WETH, allows order to be filled with ETH

--- a/test/v4/collection-orders.test.ts
+++ b/test/v4/collection-orders.test.ts
@@ -2,6 +2,8 @@ import { ethers } from 'ethers';
 import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
 
 import { SwappableAsset } from '../../src/sdk/v4/pure';
+import { SignedERC721OrderStruct } from '../../src/sdk/v4/types';
+import { NULL_ADDRESS } from '../../src/utils/eth';
 
 jest.setTimeout(90 * 1000);
 
@@ -34,22 +36,23 @@ const nftSwapperMaker = new NftSwapV4(
 );
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
-const TAKER_ASSET: SwappableAsset = {
+const MAKER_ASSET: SwappableAsset = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
   amount: '100000000000', // 1 USDC
 };
-const MAKER_ASSET: SwappableAsset = {
+
+const TAKER_ASSET: SwappableAsset = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
-  tokenId: '11045',
+  tokenId: '1',
 };
 
 describe('NFTSwapV4', () => {
   it.only('v4 erc721 test', async () => {
     // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
 
-    const v4Erc721Order = nftSwapperMaker.buildOrder(
+    const v4Erc721Order = nftSwapperMaker.buildCollectionBasedOrder(
       MAKER_ASSET,
       TAKER_ASSET,
       MAKER_WALLET_ADDRESS
@@ -59,9 +62,10 @@ describe('NFTSwapV4', () => {
       // }
     );
 
+
     // console.log('v4Erc721Order.nonce', v4Erc721Order.nonce.toString());
 
-    expect(v4Erc721Order.nonce.toString().includes('-')).toBeFalsy();
+    // expect(v4Erc721Order.nonce.toString()./includes('-')).toBeFalsy();
 
     // const makerapprovalTx = await nftSwapperMaker.approveTokenOrNftByAsset(
     //   MAKER_ASSET,
@@ -78,11 +82,21 @@ describe('NFTSwapV4', () => {
     // const takerApprovalTxHash = await (await takerApprovalTx.wait()).transactionHash
     // console.log('taker approval tx hash', takerApprovalTxHash)
 
-    // const signedOrder = await nftSwapperMaker.signOrder(v4Erc721Order);
+    const signedOrder = await nftSwapperMaker.signOrder(v4Erc721Order) as SignedERC721OrderStruct
+
+    expect(signedOrder.erc721TokenProperties[0].propertyValidator).toEqual(NULL_ADDRESS)
     // console.log('erc721 signatuee', signedOrder.signature);
     // expect(signedOrder.signature.signatureType.toString()).toEqual('2');
 
-    // const fillTx = await nftSwapperMaker.fillSignedOrder(signedOrder);
+    // const fillTx = await nftSwapperMaker.fillSignedCollectionOrder(
+    //   signedOrder,
+    //   '11045',
+    //   {
+    //     fillOrderWithNativeTokenInsteadOfWrappedToken: false,
+    //     tokenIdToSellForCollectionOrder: '11045',
+    //   },
+    //   { gasLimit: '500000' }
+    // );
     // const txReceipt = await fillTx.wait();
     // console.log('erc721 fill tx', txReceipt.transactionHash);
 


### PR DESCRIPTION
Adds [Collection-based](https://0x.org/docs/guides/0x-v4-nft-features-overview#collectionfloorproperty-based-orders) orders to NFT Swap SDK. 

These orders can be filled using any NFT from a particular collection.

The SDK provides a simple API:

```tsx
// Maker creates an order for any NFT from a collection (you can think of it as a 'bid')
// Specifically in this example, the maker will sell 1000 USDC for any NFT in the collection specificed
const v4Erc721Order = nftSwapperMaker.buildCollectionBasedOrder(
  // Selling ERC20
  {
    type: "ERC20",
    tokenAddress: USDC_TOKEN_ADDRESS,
    amount: "100000000000000", // 1000 USDC
  },
  // Bidding on NFT in the collection, just specify the contract address and whether its an ERC721 or ERC1155.
  {
    tokenAddress: NFT_CONTRACT_ADDDRESS,
    type: "ERC721", // "ERC721" | "ERC1155"
  },
  makerWalletAddress // Maker wallet address
)

const signedOrder = await nftSwapperMaker.signOrder(v4Erc721Order)

// Later, taker can sell an NFT from the specified collection, filling the bid.
const fillTx = await nftSwapperMaker.fillSignedCollectionOrder(
  signedOrder,
  "11045" // Token ID from the collection to fill order with
)

```