### PR TITLE
ADDS fee support to v4

### DIFF
--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -338,7 +338,14 @@ export const generateErc721Order = (
     maker: orderData.maker,
     // Defaults not required...
     erc721TokenProperties: orderData.tokenProperties ?? [],
-    fees: [],
+    fees:
+      orderData.fees?.map((x) => {
+        return {
+          amount: x.amount,
+          recipient: x.recipient,
+          feeData: x.feeData ?? '0x',
+        };
+      }) ?? [],
     expiry: orderData.expiry
       ? getUnixTime(orderData.expiry)
       : INFINITE_TIMESTAMP_SEC,
@@ -364,7 +371,14 @@ export const generateErc1155Order = (
     maker: orderData.maker,
     // Defaults not required...
     erc1155TokenProperties: orderData.tokenProperties ?? [],
-    fees: [],
+    fees:
+      orderData.fees?.map((x) => {
+        return {
+          amount: x.amount,
+          recipient: x.recipient,
+          feeData: x.feeData ?? '0x',
+        };
+      }) ?? [],
     expiry: orderData.expiry
       ? getUnixTime(orderData.expiry)
       : INFINITE_TIMESTAMP_SEC,

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -43,6 +43,14 @@ export type ERC721OrderStruct = {
   erc721TokenProperties: PropertyStruct[];
 };
 
+export type UserFacingFeeStruct = {
+  recipient: string;
+  amount: BigNumberish;
+  // Make fee data optional for devx (most folks don't use the feeData arg and it _needs_ to be '0x' if not being used).
+  // automatically defaults to '0x'
+  feeData?: BytesLike;
+};
+
 export interface OrderStructOptionsCommon {
   direction: BigNumberish;
   maker: string;
@@ -51,7 +59,7 @@ export interface OrderStructOptionsCommon {
   nonce: BigNumberish;
   // erc20Token: string;
   // erc20TokenAmount: BigNumberish;
-  fees: FeeStruct[];
+  fees: UserFacingFeeStruct[];
   tokenProperties: PropertyStruct[];
 }
 
@@ -63,7 +71,7 @@ export interface OrderStructOptionsCommonStrict {
   taker?: string;
   expiry?: Date | number;
   nonce?: BigNumberish;
-  fees?: FeeStruct[];
+  fees?: UserFacingFeeStruct[];
   tokenProperties?: PropertyStruct[];
 }
 

--- a/test/v4/fees.test.ts
+++ b/test/v4/fees.test.ts
@@ -39,23 +39,30 @@ const nftSwapperMaker = new NftSwapV4(
 const MAKER_ASSET: SwappableAsset = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
-  amount: '100000000000', // 1 USDC
+  amount: '420000000000000', // 1 USDC
 };
 
 const TAKER_ASSET: SwappableAsset = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
-  tokenId: '1',
+  tokenId: '11045',
 };
 
 describe('NFTSwapV4', () => {
-  it.only('collection orders test', async () => {
+  it.only('fees', async () => {
     // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
-
-    const v4Erc721Order = nftSwapperMaker.buildCollectionBasedOrder(
-      MAKER_ASSET,
+    const v4Erc721Order = nftSwapperMaker.buildOrder(
       TAKER_ASSET,
-      MAKER_WALLET_ADDRESS
+      MAKER_ASSET,
+      MAKER_WALLET_ADDRESS,
+      {
+        fees: [
+          {
+            amount: '6900000000000',
+            recipient: '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34',
+          },
+        ],
+      }
       // {
       //   // Fix dates and salt so we have reproducible tests
       //   expiration: new Date(3000, 10, 1),
@@ -85,8 +92,8 @@ describe('NFTSwapV4', () => {
       v4Erc721Order
     )) as SignedERC721OrderStruct;
 
-    expect(signedOrder.erc721TokenProperties[0].propertyValidator).toEqual(
-      NULL_ADDRESS
+    expect(signedOrder.fees[0].recipient).toEqual(
+      '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34'
     );
     // console.log('erc721 signatuee', signedOrder.signature);
     // expect(signedOrder.signature.signatureType.toString()).toEqual('2');
@@ -117,16 +124,11 @@ describe('NFTSwapV4', () => {
     // );
 
     // Uncomment to actually fill order
-    // const tx = await nftSwapperMaker.fillSignedOrder(signedOrder, undefined, {
-    //   gasPrice,
-    //   gasLimit: '500000',
-    //   // HACK(johnnrjj) - Rinkeby still has protocol fees, so we give it a little bit of ETH so its happy.
-    //   value: parseEther('0.01'),
-    // });
+    // const tx = await nftSwapperMaker.fillSignedOrder(signedOrder)//, undefined, { gasLimit: '500000'})
 
     // const txReceipt = await tx.wait();
     // expect(txReceipt.transactionHash).toBeTruthy();
-    // console.log(`Swapped on Rinkeby (txHAsh: ${txReceipt.transactionIndex})`);
+    // console.log(`Swapped on Rinkeby (txHAsh: ${txReceipt.transactionHash})`);
   });
 });
 


### PR DESCRIPTION
Adds fee support to NFT Swap SDK. Add as many fee recipients and amounts as you'd like.

Fees can be specified by: 
```ts
interface Fee {
    recipient: string // The address to send the fee to
    amount: string // The amount (based in the same erc20Token) to charge for fee
    feeData?: string | undefined; // optional feeData callback
}
```

Important notes:
- Buyer of the NFT pays the fee(s)
- Fees are **in addition** to the `erc20TokenAmount` that the buyer is paying for the NFT itself

```tsx
const MAKER_ASSET: SwappableAsset = {
  type: 'ERC721',
  tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
  tokenId: '11045',
};

const TAKER_ASSET: SwappableAsset = {
  type: 'ERC20',
  tokenAddress: USDC_TOKEN_ADDRESS,
  amount: '420000000000000', // 4200 USDC
};

const v4Erc721Order = nftSwapper.buildOrder(
  MAKER_ASSET,
  TAKER_ASSET,
  MAKER_WALLET_ADDRESS,
  {
    fees: [
      {
        amount: '6900000000000', // 69 USDC fee
        recipient: '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34', // your DAO treasury 
      },
    ],
  }
);
```

Spec: For each Fee specified in an order, the buyer of the NFT will pay the fee recipient the given amount of ETH/ERC20 tokens. This is in addition to the `erc20TokenAmount` that the buyer is paying for the NFT itself. There is an optional callback for each fee: