### PR TITLE
No approvals required when taker sells NFT by accepting a bid

### DIFF
--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -1,7 +1,12 @@
 import { Signer, TypedDataSigner } from '@ethersproject/abstract-signer';
 import { BaseProvider, TransactionReceipt } from '@ethersproject/providers';
 import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
-import { IZeroEx, IZeroEx__factory } from '../../contracts';
+import {
+  ERC1155__factory,
+  ERC721__factory,
+  IZeroEx,
+  IZeroEx__factory,
+} from '../../contracts';
 import type {
   ApprovalStatus,
   BaseNftSwap,
@@ -30,15 +35,22 @@ import {
 import type {
   AddressesForChain,
   ApprovalOverrides,
+  FeeStruct,
   FillOrderOverrides,
   NftOrderV4,
   OrderStructOptionsCommonStrict,
+  PropertyStruct,
   SignedNftOrderV4,
   SigningOptions,
 } from './types';
 import addresses from './addresses.json';
 import invariant from 'tiny-invariant';
 import { NULL_ADDRESS } from '../../utils/eth';
+import { defaultAbiCoder, Interface } from '@ethersproject/abi';
+import {
+  ERC1155_ENCODED_ORDER_DATA,
+  ERC721_ENCODED_ORDER_DATA,
+} from './nft-safe-transfer-from-data';
 
 export enum SupportedChainIdsV4 {
   Ropsten = 3,
@@ -105,6 +117,21 @@ export interface INftSwapV4 extends BaseNftSwap {
   //   takerAssets: SwappableAsset[];
   // };
 }
+
+export type ERC1155OrderStruct = {
+  direction: BigNumberish;
+  maker: string;
+  taker: string;
+  expiry: BigNumberish;
+  nonce: BigNumberish;
+  erc20Token: string;
+  erc20TokenAmount: BigNumberish;
+  fees: FeeStruct[];
+  erc1155Token: string;
+  erc1155TokenId: BigNumberish;
+  erc1155TokenProperties: PropertyStruct[];
+  erc1155TokenAmount: BigNumberish;
+};
 
 export interface AdditionalSdkConfig {
   zeroExExchangeProxyContractAddress: string;
@@ -362,6 +389,97 @@ class NftSwapV4 implements INftSwapV4 {
       },
     };
     return signedOrder;
+  };
+
+  /**
+   * Fill a 'Buy NFT' order (e.g. taker would be selling'their NFT to fill this order) without needing an approval
+   * Use case: Users can accept offers/bids for their NFTs without needing to approve their NFT! 🤯
+   * @param signedOrder Signed Buy Nft order (e.g. direction = 1)
+   * @param tokenId NFT token id that taker of trade will sell
+   * @param fillOrderOverrides Trade specific (SDK-level) overrides
+   * @param transactionOverrides General transaction overrides from ethers (gasPrice, gasLimit, etc)
+   * @returns 
+   */
+  fillBuyNftOrderWithoutApproval = async (
+    signedOrder: SignedNftOrderV4,
+    tokenId: string,
+    fillOrderOverrides?: Partial<FillOrderOverrides>,
+    transactionOverrides?: Partial<PayableOverrides>
+  ) => {
+    if (!this.signer) {
+      throw new Error(
+        'Signer undefined. Signer must be provided to fill order'
+      );
+    }
+    if (signedOrder.direction !== TradeDirection.BuyNFT) {
+      throw new Error(
+        'Only filling Buy NFT orders (direction=1) is valid for skipping approvals'
+      );
+    }
+
+    const signerAddress = await this.signer.getAddress();
+    const unwrapWeth =
+      fillOrderOverrides?.fillOrderWithNativeTokenInsteadOfWrappedToken ??
+      false;
+
+    // Handle ERC721
+    if ('erc721Token' in signedOrder) {
+      const erc721Contract = ERC721__factory.connect(
+        signedOrder.erc721Token,
+        this.signer
+      );
+
+      const encodingIface = new Interface(ERC721_ENCODED_ORDER_DATA);
+
+      const fragment = encodingIface.getFunction('safeTransferFromErc721Data');
+      const data = encodingIface._encodeParams(fragment.inputs, [
+        signedOrder,
+        signedOrder.signature,
+        unwrapWeth,
+      ]);
+
+      const transferFromTx = await erc721Contract[
+        'safeTransferFrom(address,address,uint256,bytes)'
+      ](
+        signerAddress,
+        this.exchangeProxy.address,
+        fillOrderOverrides?.tokenIdToSellForCollectionOrder ?? tokenId,
+        data,
+        transactionOverrides ?? {}
+      );
+      return transferFromTx;
+    }
+
+    // Handle ERC1155
+    if ('erc1155Token' in signedOrder) {
+      const erc1155Contract = ERC1155__factory.connect(
+        signedOrder.erc1155Token,
+        this.signer
+      );
+      const encodingIface = new Interface(ERC1155_ENCODED_ORDER_DATA);
+
+      const fragment = encodingIface.getFunction('safeTransferFromErc1155Data');
+      const data = encodingIface._encodeParams(fragment.inputs, [
+        signedOrder,
+        signedOrder.signature,
+        unwrapWeth,
+      ]);
+
+      const transferFromTx = await erc1155Contract.safeTransferFrom(
+        signerAddress,
+        this.exchangeProxy.address,
+        tokenId,
+        fillOrderOverrides?.tokenIdToSellForCollectionOrder ??
+          signedOrder.erc1155TokenAmount ??
+          '1',
+        data,
+        transactionOverrides ?? {}
+      );
+      return transferFromTx;
+    }
+
+    // Unknown format (NFT neither ERC721 or ERC1155)
+    throw new Error('unknown order type');
   };
 
   fillSignedCollectionOrder = async (

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -453,10 +453,8 @@ class NftSwapV4 implements INftSwapV4 {
       const transferFromTx = await erc1155Contract.safeTransferFrom(
         signerAddress,
         this.exchangeProxy.address,
-        tokenId,
-        fillOrderOverrides?.tokenIdToSellForCollectionOrder ??
-          signedOrder.erc1155TokenAmount ??
-          '1',
+        fillOrderOverrides?.tokenIdToSellForCollectionOrder ?? tokenId,
+        signedOrder.erc1155TokenAmount ?? '1',
         data,
         transactionOverrides ?? {}
       );

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -1,6 +1,11 @@
-import { Signer, TypedDataSigner } from '@ethersproject/abstract-signer';
-import { BaseProvider, TransactionReceipt } from '@ethersproject/providers';
-import { BigNumber, BigNumberish, ContractTransaction } from 'ethers';
+import type { Signer, TypedDataSigner } from '@ethersproject/abstract-signer';
+import type {
+  BaseProvider,
+  TransactionReceipt,
+} from '@ethersproject/providers';
+import type { BigNumberish, ContractTransaction } from 'ethers';
+import { Interface } from '@ethersproject/abi';
+import invariant from 'tiny-invariant';
 import {
   ERC1155__factory,
   ERC721__factory,
@@ -35,22 +40,17 @@ import {
 import type {
   AddressesForChain,
   ApprovalOverrides,
-  FeeStruct,
   FillOrderOverrides,
   NftOrderV4,
   OrderStructOptionsCommonStrict,
-  PropertyStruct,
   SignedNftOrderV4,
   SigningOptions,
 } from './types';
-import addresses from './addresses.json';
-import invariant from 'tiny-invariant';
-import { NULL_ADDRESS } from '../../utils/eth';
-import { defaultAbiCoder, Interface } from '@ethersproject/abi';
 import {
-  ERC1155_ENCODED_ORDER_DATA,
-  ERC721_ENCODED_ORDER_DATA,
+  ERC1155_TRANSFER_FROM_DATA,
+  ERC721_TRANSFER_FROM_DATA,
 } from './nft-safe-transfer-from-data';
+import addresses from './addresses.json';
 
 export enum SupportedChainIdsV4 {
   Ropsten = 3,
@@ -117,21 +117,6 @@ export interface INftSwapV4 extends BaseNftSwap {
   //   takerAssets: SwappableAsset[];
   // };
 }
-
-export type ERC1155OrderStruct = {
-  direction: BigNumberish;
-  maker: string;
-  taker: string;
-  expiry: BigNumberish;
-  nonce: BigNumberish;
-  erc20Token: string;
-  erc20TokenAmount: BigNumberish;
-  fees: FeeStruct[];
-  erc1155Token: string;
-  erc1155TokenId: BigNumberish;
-  erc1155TokenProperties: PropertyStruct[];
-  erc1155TokenAmount: BigNumberish;
-};
 
 export interface AdditionalSdkConfig {
   zeroExExchangeProxyContractAddress: string;
@@ -398,7 +383,7 @@ class NftSwapV4 implements INftSwapV4 {
    * @param tokenId NFT token id that taker of trade will sell
    * @param fillOrderOverrides Trade specific (SDK-level) overrides
    * @param transactionOverrides General transaction overrides from ethers (gasPrice, gasLimit, etc)
-   * @returns 
+   * @returns
    */
   fillBuyNftOrderWithoutApproval = async (
     signedOrder: SignedNftOrderV4,
@@ -429,7 +414,7 @@ class NftSwapV4 implements INftSwapV4 {
         this.signer
       );
 
-      const encodingIface = new Interface(ERC721_ENCODED_ORDER_DATA);
+      const encodingIface = new Interface(ERC721_TRANSFER_FROM_DATA);
 
       const fragment = encodingIface.getFunction('safeTransferFromErc721Data');
       const data = encodingIface._encodeParams(fragment.inputs, [
@@ -456,7 +441,7 @@ class NftSwapV4 implements INftSwapV4 {
         signedOrder.erc1155Token,
         this.signer
       );
-      const encodingIface = new Interface(ERC1155_ENCODED_ORDER_DATA);
+      const encodingIface = new Interface(ERC1155_TRANSFER_FROM_DATA);
 
       const fragment = encodingIface.getFunction('safeTransferFromErc1155Data');
       const data = encodingIface._encodeParams(fragment.inputs, [

--- a/src/sdk/v4/nft-safe-transfer-from-data.ts
+++ b/src/sdk/v4/nft-safe-transfer-from-data.ts
@@ -1,0 +1,270 @@
+export const ERC721_ENCODED_ORDER_DATA = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'enum LibNFTOrder.TradeDirection',
+            name: 'direction',
+            type: 'uint8',
+          },
+          {
+            internalType: 'address',
+            name: 'maker',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'taker',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'expiry',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'nonce',
+            type: 'uint256',
+          },
+          {
+            internalType: 'contract IERC20TokenV06',
+            name: 'erc20Token',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'erc20TokenAmount',
+            type: 'uint256',
+          },
+          {
+            components: [
+              {
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+              },
+              {
+                internalType: 'bytes',
+                name: 'feeData',
+                type: 'bytes',
+              },
+            ],
+            internalType: 'struct LibNFTOrder.Fee[]',
+            name: 'fees',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'contract IERC721Token',
+            name: 'erc721Token',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'erc721TokenId',
+            type: 'uint256',
+          },
+          {
+            components: [
+              {
+                internalType: 'contract IPropertyValidator',
+                name: 'propertyValidator',
+                type: 'address',
+              },
+              {
+                internalType: 'bytes',
+                name: 'propertyData',
+                type: 'bytes',
+              },
+            ],
+            internalType: 'struct LibNFTOrder.Property[]',
+            name: 'erc721TokenProperties',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct LibNFTOrder.ERC721Order',
+        name: 'order',
+        type: 'tuple',
+      },
+      {
+        components: [
+          {
+            internalType: 'enum LibSignature.SignatureType',
+            name: 'signatureType',
+            type: 'uint8',
+          },
+          {
+            internalType: 'uint8',
+            name: 'v',
+            type: 'uint8',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'r',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 's',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct LibSignature.Signature',
+        name: 'signature',
+        type: 'tuple',
+      },
+      {
+        name: 'unwrapNativeToken',
+        type: 'bool',
+      },
+    ],
+    name: 'safeTransferFromErc721Data',
+    outputs: [],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+export const ERC1155_ENCODED_ORDER_DATA = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'enum LibNFTOrder.TradeDirection',
+            name: 'direction',
+            type: 'uint8',
+          },
+          {
+            internalType: 'address',
+            name: 'maker',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'taker',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'expiry',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'nonce',
+            type: 'uint256',
+          },
+          {
+            internalType: 'contract IERC20TokenV06',
+            name: 'erc20Token',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'erc20TokenAmount',
+            type: 'uint256',
+          },
+          {
+            components: [
+              {
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+              },
+              {
+                internalType: 'bytes',
+                name: 'feeData',
+                type: 'bytes',
+              },
+            ],
+            internalType: 'struct LibNFTOrder.Fee[]',
+            name: 'fees',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'contract IERC1155Token',
+            name: 'erc1155Token',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'erc1155TokenId',
+            type: 'uint256',
+          },
+          {
+            components: [
+              {
+                internalType: 'contract IPropertyValidator',
+                name: 'propertyValidator',
+                type: 'address',
+              },
+              {
+                internalType: 'bytes',
+                name: 'propertyData',
+                type: 'bytes',
+              },
+            ],
+            internalType: 'struct LibNFTOrder.Property[]',
+            name: 'erc1155TokenProperties',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'uint128',
+            name: 'erc1155TokenAmount',
+            type: 'uint128',
+          },
+        ],
+        internalType: 'struct LibNFTOrder.ERC1155Order[]',
+        name: 'sellOrders',
+        type: 'tuple[]',
+      },
+      {
+        components: [
+          {
+            internalType: 'enum LibSignature.SignatureType',
+            name: 'signatureType',
+            type: 'uint8',
+          },
+          {
+            internalType: 'uint8',
+            name: 'v',
+            type: 'uint8',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'r',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 's',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct LibSignature.Signature',
+        name: 'signature',
+        type: 'tuple',
+      },
+      {
+        name: 'unwrapNativeToken',
+        type: 'bool',
+      },
+    ],
+    name: 'safeTransferFromErc1155Data',
+    outputs: [],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/src/sdk/v4/nft-safe-transfer-from-data.ts
+++ b/src/sdk/v4/nft-safe-transfer-from-data.ts
@@ -1,4 +1,4 @@
-export const ERC721_ENCODED_ORDER_DATA = [
+export const ERC721_TRANSFER_FROM_DATA = [
   {
     inputs: [
       {
@@ -131,7 +131,7 @@ export const ERC721_ENCODED_ORDER_DATA = [
   },
 ];
 
-export const ERC1155_ENCODED_ORDER_DATA = [
+export const ERC1155_TRANSFER_FROM_DATA = [
   {
     inputs: [
       {

--- a/test/v4/collection-orders.test.ts
+++ b/test/v4/collection-orders.test.ts
@@ -49,7 +49,7 @@ const TAKER_ASSET: SwappableAsset = {
 };
 
 describe('NFTSwapV4', () => {
-  it.only('collection orders test', async () => {
+  it('collection orders test', async () => {
     // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
 
     const v4Erc721Order = nftSwapperMaker.buildCollectionBasedOrder(

--- a/test/v4/sell-nft-no-approval.test.ts
+++ b/test/v4/sell-nft-no-approval.test.ts
@@ -80,16 +80,16 @@ describe('NFTSwapV4', () => {
       v4Erc721Order
     )) as SignedERC721OrderStruct;
 
-    const tx = await nftSwapperMaker.fillSellNftOrderWithoutApproval(
-      signedOrder,
-      '11045'
-    );
-    const txReceipt = await tx.wait();
+    // const tx = await nftSwapperMaker.fillBuyNftOrderWithoutApproval(
+    //   signedOrder,
+    //   '11045'
+    // );
+    // const txReceipt = await tx.wait();
 
-    expect(txReceipt.transactionHash).toBeTruthy();
-    console.log(
-      `Swapped on Rinkeby without approval using safeTransferFrom (txHAsh: ${txReceipt.transactionHash})`
-    );
+    // expect(txReceipt.transactionHash).toBeTruthy();
+    // console.log(
+    //   `Swapped on Rinkeby without approval using safeTransferFrom (txHAsh: ${txReceipt.transactionHash})`
+    // );
 
     // console.log('erc721 signatuee', signedOrder.signature);
     // expect(signedOrder.signature.signatureType.toString()).toEqual('2');

--- a/test/v4/smoke-test-swap.test.ts
+++ b/test/v4/smoke-test-swap.test.ts
@@ -46,7 +46,7 @@ const MAKER_ASSET: SwappableAsset = {
 };
 
 describe('NFTSwapV4', () => {
-  it.only('v4 erc721 test', async () => {
+  it('v4 erc721 test', async () => {
     // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
 
     const v4Erc721Order = nftSwapperMaker.buildOrder(


### PR DESCRIPTION
Alpha leak.

If a user receives a bid on their NFT, they can accept the bid without needing to approve the NFT for transfer/swap first.

Simply call `fillBuyNftOrderWithoutApproval` instead of `fillSignedOrder` with the Swap SDK.

This provides the most seamless UX for accepting NFT bids on Ethereum, no more two-step process, and saves users money.

More info [here](https://0x.org/docs/guides/0x-v4-nft-features-overview#onerc721received-and-onerc1155received)