### PR TITLE
Serializes order on buildOrder function

### DIFF
--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -42,6 +42,7 @@ import type {
   ApprovalOverrides,
   FillOrderOverrides,
   NftOrderV4,
+  NftOrderV4Serialized,
   OrderStructOptionsCommonStrict,
   SignedNftOrderV4,
   SigningOptions,
@@ -71,7 +72,7 @@ export interface INftSwapV4 extends BaseNftSwap {
     sellOrBuyNft: 'sell' | 'buy',
     makerAddress: string,
     userConfig?: Partial<OrderStructOptionsCommonStrict>
-  ) => NftOrderV4;
+  ) => NftOrderV4Serialized;
   loadApprovalStatus: (
     asset: SwappableAsset,
     walletAddress: string,
@@ -225,25 +226,25 @@ class NftSwapV4 implements INftSwapV4 {
     takerAsset: UserFacingERC20AssetDataSerialized,
     makerAddress: string,
     orderConfig?: Partial<OrderStructOptionsCommonStrict>
-  ): NftOrderV4;
+  ): NftOrderV4Serialized;
   buildOrder(
     makerAsset: UserFacingERC20AssetDataSerialized,
     takerAsset: UserFacingERC1155AssetDataSerializedNormalizedSingle,
     makerAddress: string,
     orderConfig?: Partial<OrderStructOptionsCommonStrict>
-  ): NftOrderV4;
+  ): NftOrderV4Serialized;
   buildOrder(
     makerAsset: UserFacingERC721AssetDataSerialized,
     takerAsset: UserFacingERC20AssetDataSerialized,
     makerAddress: string,
     orderConfig?: Partial<OrderStructOptionsCommonStrict>
-  ): NftOrderV4;
+  ): NftOrderV4Serialized;
   buildOrder(
     makerAsset: UserFacingERC20AssetDataSerialized,
     takerAsset: UserFacingERC721AssetDataSerialized,
     makerAddress: string,
     orderConfig?: Partial<OrderStructOptionsCommonStrict>
-  ): NftOrderV4;
+  ): NftOrderV4Serialized;
   buildOrder(
     makerAsset: SwappableAsset,
     takerAsset: SwappableAsset,
@@ -299,7 +300,7 @@ class NftSwapV4 implements INftSwapV4 {
       type: 'ERC721' | 'ERC1155';
     },
     makerAddress: string
-  ) => {
+  ): NftOrderV4Serialized => {
     return this.buildNftAndErc20Order(
       {
         ...nftCollectionToBid,
@@ -322,7 +323,7 @@ class NftSwapV4 implements INftSwapV4 {
     sellOrBuyNft: 'sell' | 'buy' = 'sell',
     makerAddress: string,
     userConfig?: Partial<OrderStructOptionsCommonStrict>
-  ): NftOrderV4 => {
+  ): NftOrderV4Serialized => {
     const defaultConfig = { chainId: this.chainId, makerAddress: makerAddress };
     const config = { ...defaultConfig, ...userConfig };
 

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -350,13 +350,13 @@ class NftSwapV4 implements INftSwapV4 {
     }
   };
 
-  signOrder = async (orderStruct: NftOrderV4): Promise<SignedNftOrderV4> => {
+  signOrder = async (order: NftOrderV4): Promise<SignedNftOrderV4> => {
     if (!this.signer) {
       throw new Error('Signed not defined');
     }
 
     const rawSignature = await signOrderWithEoaWallet(
-      orderStruct,
+      order,
       this.signer as unknown as TypedDataSigner,
       this.chainId,
       this.exchangeProxy.address
@@ -365,7 +365,7 @@ class NftSwapV4 implements INftSwapV4 {
     const ecSignature = parseRawSignature(rawSignature);
 
     const signedOrder = {
-      ...orderStruct,
+      ...order,
       signature: {
         signatureType: 2,
         r: ecSignature.r,

--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -334,14 +334,14 @@ export const generateErc721Order = (
   const erc721Order: ERC721OrderStructSerialized = {
     erc721Token: nft.tokenAddress,
     erc721TokenId: nft.tokenId,
-    direction: orderData.direction.toString(10),
+    direction: parseInt(orderData.direction.toString()), // KLUDGE(johnrjj) - There's some footgun here when only doing orderData.direction.toString(), need to parseInt it
     erc20Token: erc20.tokenAddress,
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,
     // Defaults not required...
     erc721TokenProperties:
       orderData.tokenProperties?.map((property) => ({
-        propertyData: property.propertyData.toString(),
+        propertyData: property.propertyData,
         propertyValidator: property.propertyValidator,
       })) ?? [],
     fees:
@@ -371,7 +371,7 @@ export const generateErc1155Order = (
     erc1155Token: nft.tokenAddress,
     erc1155TokenId: nft.tokenId,
     erc1155TokenAmount: nft.amount ?? '1',
-    direction: orderData.direction.toString(10),
+    direction: orderData.direction.toString(),
     erc20Token: erc20.tokenAddress,
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,

--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -332,12 +332,12 @@ export const generateErc721Order = (
   orderData: Partial<OrderStructOptionsCommon> & OrderStructOptionsCommonStrict
 ): ERC721OrderStructSerialized => {
   const erc721Order: ERC721OrderStructSerialized = {
-    erc721Token: nft.tokenAddress,
+    erc721Token: nft.tokenAddress.toLowerCase(),
     erc721TokenId: nft.tokenId,
     direction: parseInt(orderData.direction.toString()), // KLUDGE(johnrjj) - There's some footgun here when only doing orderData.direction.toString(), need to parseInt it
-    erc20Token: erc20.tokenAddress,
+    erc20Token: erc20.tokenAddress.toLowerCase(),
     erc20TokenAmount: erc20.amount,
-    maker: orderData.maker,
+    maker: orderData.maker.toLowerCase(),
     // Defaults not required...
     erc721TokenProperties:
       orderData.tokenProperties?.map((property) => ({
@@ -348,7 +348,7 @@ export const generateErc721Order = (
       orderData.fees?.map((x) => {
         return {
           amount: x.amount.toString(),
-          recipient: x.recipient,
+          recipient: x.recipient.toLowerCase(),
           feeData: x.feeData?.toString() ?? '0x',
         };
       }) ?? [],
@@ -356,7 +356,7 @@ export const generateErc721Order = (
       ? getUnixTime(orderData.expiry).toString()
       : INFINITE_TIMESTAMP_SEC.toString(),
     nonce: orderData.nonce?.toString() ?? generateRandomNonce(),
-    taker: orderData.taker ?? NULL_ADDRESS,
+    taker: orderData.taker?.toLowerCase() ?? NULL_ADDRESS,
   };
 
   return erc721Order;
@@ -368,13 +368,13 @@ export const generateErc1155Order = (
   orderData: Partial<OrderStructOptionsCommon> & OrderStructOptionsCommonStrict
 ): ERC1155OrderStructSerialized => {
   const erc1155Order: ERC1155OrderStructSerialized = {
-    erc1155Token: nft.tokenAddress,
+    erc1155Token: nft.tokenAddress.toLowerCase(),
     erc1155TokenId: nft.tokenId,
     erc1155TokenAmount: nft.amount ?? '1',
     direction: parseInt(orderData.direction.toString()), // KLUDGE(johnrjj) - There's some footgun here when only doing orderData.direction.toString(), need to parseInt it
-    erc20Token: erc20.tokenAddress,
+    erc20Token: erc20.tokenAddress.toLowerCase(),
     erc20TokenAmount: erc20.amount,
-    maker: orderData.maker,
+    maker: orderData.maker.toLowerCase(),
     // Defaults not required...
     erc1155TokenProperties:
       orderData.tokenProperties?.map((property) => ({
@@ -385,7 +385,7 @@ export const generateErc1155Order = (
       orderData.fees?.map((fee) => {
         return {
           amount: fee.amount.toString(),
-          recipient: fee.recipient,
+          recipient: fee.recipient.toLowerCase(),
           feeData: fee.feeData?.toString() ?? '0x',
         };
       }) ?? [],
@@ -393,7 +393,7 @@ export const generateErc1155Order = (
       ? getUnixTime(orderData.expiry).toString()
       : INFINITE_TIMESTAMP_SEC.toString(),
     nonce: orderData.nonce?.toString() ?? generateRandomNonce(),
-    taker: orderData.taker ?? NULL_ADDRESS,
+    taker: orderData.taker?.toLowerCase() ?? NULL_ADDRESS,
   };
 
   return erc1155Order;

--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -371,7 +371,7 @@ export const generateErc1155Order = (
     erc1155Token: nft.tokenAddress,
     erc1155TokenId: nft.tokenId,
     erc1155TokenAmount: nft.amount ?? '1',
-    direction: orderData.direction.toString(),
+    direction: parseInt(orderData.direction.toString()), // KLUDGE(johnrjj) - There's some footgun here when only doing orderData.direction.toString(), need to parseInt it
     erc20Token: erc20.tokenAddress,
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,

--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -14,7 +14,9 @@ import { UnexpectedAssetTypeError } from '../error';
 import type {
   ECSignature,
   ERC1155OrderStruct,
+  ERC1155OrderStructSerialized,
   ERC721OrderStruct,
+  ERC721OrderStructSerialized,
   NftOrderV4,
   OrderStructOptionsCommon,
   OrderStructOptionsCommonStrict,
@@ -328,28 +330,32 @@ export const generateErc721Order = (
   nft: UserFacingERC721AssetDataSerialized,
   erc20: UserFacingERC20AssetDataSerialized,
   orderData: Partial<OrderStructOptionsCommon> & OrderStructOptionsCommonStrict
-): ERC721OrderStruct => {
-  const erc721Order: ERC721OrderStruct = {
+): ERC721OrderStructSerialized => {
+  const erc721Order: ERC721OrderStructSerialized = {
     erc721Token: nft.tokenAddress,
     erc721TokenId: nft.tokenId,
-    direction: orderData.direction,
+    direction: orderData.direction.toString(10),
     erc20Token: erc20.tokenAddress,
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,
     // Defaults not required...
-    erc721TokenProperties: orderData.tokenProperties ?? [],
+    erc721TokenProperties:
+      orderData.tokenProperties?.map((property) => ({
+        propertyData: property.propertyData.toString(),
+        propertyValidator: property.propertyValidator,
+      })) ?? [],
     fees:
       orderData.fees?.map((x) => {
         return {
-          amount: x.amount,
+          amount: x.amount.toString(),
           recipient: x.recipient,
-          feeData: x.feeData ?? '0x',
+          feeData: x.feeData?.toString() ?? '0x',
         };
       }) ?? [],
     expiry: orderData.expiry
-      ? getUnixTime(orderData.expiry)
-      : INFINITE_TIMESTAMP_SEC,
-    nonce: orderData.nonce ?? generateRandomNonce(),
+      ? getUnixTime(orderData.expiry).toString()
+      : INFINITE_TIMESTAMP_SEC.toString(),
+    nonce: orderData.nonce?.toString() ?? generateRandomNonce(),
     taker: orderData.taker ?? NULL_ADDRESS,
   };
 
@@ -360,29 +366,33 @@ export const generateErc1155Order = (
   nft: UserFacingERC1155AssetDataSerializedNormalizedSingle,
   erc20: UserFacingERC20AssetDataSerialized,
   orderData: Partial<OrderStructOptionsCommon> & OrderStructOptionsCommonStrict
-): ERC1155OrderStruct => {
-  const erc1155Order: ERC1155OrderStruct = {
+): ERC1155OrderStructSerialized => {
+  const erc1155Order: ERC1155OrderStructSerialized = {
     erc1155Token: nft.tokenAddress,
     erc1155TokenId: nft.tokenId,
     erc1155TokenAmount: nft.amount ?? '1',
-    direction: orderData.direction,
+    direction: orderData.direction.toString(10),
     erc20Token: erc20.tokenAddress,
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker,
     // Defaults not required...
-    erc1155TokenProperties: orderData.tokenProperties ?? [],
+    erc1155TokenProperties:
+      orderData.tokenProperties?.map((property) => ({
+        propertyData: property.propertyData.toString(),
+        propertyValidator: property.propertyValidator,
+      })) ?? [],
     fees:
-      orderData.fees?.map((x) => {
+      orderData.fees?.map((fee) => {
         return {
-          amount: x.amount,
-          recipient: x.recipient,
-          feeData: x.feeData ?? '0x',
+          amount: fee.amount.toString(),
+          recipient: fee.recipient,
+          feeData: fee.feeData?.toString() ?? '0x',
         };
       }) ?? [],
     expiry: orderData.expiry
-      ? getUnixTime(orderData.expiry)
-      : INFINITE_TIMESTAMP_SEC,
-    nonce: orderData.nonce ?? generateRandomNonce(),
+      ? getUnixTime(orderData.expiry).toString()
+      : INFINITE_TIMESTAMP_SEC.toString(),
+    nonce: orderData.nonce?.toString() ?? generateRandomNonce(),
     taker: orderData.taker ?? NULL_ADDRESS,
   };
 

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -6,7 +6,7 @@ import type { IZeroEx } from '../../contracts';
 export type FeeStruct = {
   recipient: string;
   amount: BigNumberish;
-  feeData: BytesLike;
+  feeData: string | Array<number>;
 };
 
 export type FeeStructSerialized = {
@@ -17,12 +17,12 @@ export type FeeStructSerialized = {
 
 export type PropertyStruct = {
   propertyValidator: string;
-  propertyData: BytesLike;
+  propertyData: string | Array<number>;
 };
 
 export type PropertyStructSerialized = {
   propertyValidator: string;
-  propertyData: string;
+  propertyData: string | Array<number>;
 };
 
 export type ERC1155OrderStruct = {
@@ -70,7 +70,7 @@ export type ERC721OrderStruct = {
 };
 
 export type ERC721OrderStructSerialized = {
-  direction: string;
+  direction: number;
   maker: string;
   taker: string;
   expiry: string;
@@ -159,16 +159,16 @@ export type SignedNftOrderV4Serialized =
   | SignedERC1155OrderStructSerialized;
 
 export type ECSignature = {
-  v: BigNumberish;
-  r: BytesLike;
-  s: BytesLike;
+  v: string | number;
+  r: string | Array<number>;
+  s: string | Array<number>;
 };
 
 export type SignatureStruct = {
-  signatureType: BigNumberish; // 2 for EIP-712
-  v: BigNumberish;
-  r: BytesLike;
-  s: BytesLike;
+  signatureType: number | string; // 2 for EIP-712
+  v: number | string;
+  r: string | Array<number>;
+  s: string | Array<number>;
 };
 
 export type SignatureStructSerialized = {

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -9,9 +9,20 @@ export type FeeStruct = {
   feeData: BytesLike;
 };
 
+export type FeeStructSerialized = {
+  recipient: string;
+  amount: string;
+  feeData: string;
+};
+
 export type PropertyStruct = {
   propertyValidator: string;
   propertyData: BytesLike;
+};
+
+export type PropertyStructSerialized = {
+  propertyValidator: string;
+  propertyData: string;
 };
 
 export type ERC1155OrderStruct = {
@@ -29,6 +40,21 @@ export type ERC1155OrderStruct = {
   erc1155TokenAmount: BigNumberish;
 };
 
+export type ERC1155OrderStructSerialized = {
+  direction: string;
+  maker: string;
+  taker: string;
+  expiry: string;
+  nonce: string;
+  erc20Token: string;
+  erc20TokenAmount: string;
+  fees: FeeStructSerialized[];
+  erc1155Token: string;
+  erc1155TokenId: string;
+  erc1155TokenProperties: PropertyStructSerialized[];
+  erc1155TokenAmount: string;
+};
+
 export type ERC721OrderStruct = {
   direction: BigNumberish;
   maker: string;
@@ -41,6 +67,20 @@ export type ERC721OrderStruct = {
   erc721Token: string;
   erc721TokenId: BigNumberish;
   erc721TokenProperties: PropertyStruct[];
+};
+
+export type ERC721OrderStructSerialized = {
+  direction: string;
+  maker: string;
+  taker: string;
+  expiry: string;
+  nonce: string;
+  erc20Token: string;
+  erc20TokenAmount: string;
+  fees: FeeStructSerialized[];
+  erc721Token: string;
+  erc721TokenId: string;
+  erc721TokenProperties: PropertyStructSerialized[];
 };
 
 export type UserFacingFeeStruct = {
@@ -75,10 +115,6 @@ export interface OrderStructOptionsCommonStrict {
   tokenProperties?: PropertyStruct[];
 }
 
-interface OrderStructPropertyOptions {
-  tokenProperties: PropertyStruct[];
-}
-
 export interface Fee {
   recipient: string;
   amount: BigNumber;
@@ -92,6 +128,10 @@ export interface Property {
 
 export type NftOrderV4 = ERC1155OrderStruct | ERC721OrderStruct;
 
+export type NftOrderV4Serialized =
+  | ERC1155OrderStructSerialized
+  | ERC721OrderStructSerialized;
+
 export interface SignedERC721OrderStruct extends ERC721OrderStruct {
   signature: SignatureStruct;
 }
@@ -100,9 +140,23 @@ export interface SignedERC1155OrderStruct extends ERC1155OrderStruct {
   signature: SignatureStruct;
 }
 
+export interface SignedERC721OrderStructSerialized
+  extends ERC721OrderStructSerialized {
+  signature: SignatureStructSerialized;
+}
+
+export interface SignedERC1155OrderStructSerialized
+  extends ERC1155OrderStructSerialized {
+  signature: SignatureStructSerialized;
+}
+
 export type SignedNftOrderV4 =
   | SignedERC721OrderStruct
   | SignedERC1155OrderStruct;
+
+export type SignedNftOrderV4Serialized =
+  | SignedERC721OrderStructSerialized
+  | SignedERC1155OrderStructSerialized;
 
 export type ECSignature = {
   v: BigNumberish;
@@ -115,6 +169,13 @@ export type SignatureStruct = {
   v: BigNumberish;
   r: BytesLike;
   s: BytesLike;
+};
+
+export type SignatureStructSerialized = {
+  signatureType: number; // 2 for EIP-712
+  v: string;
+  r: string;
+  s: string;
 };
 
 export interface ApprovalOverrides {

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -159,21 +159,21 @@ export type SignedNftOrderV4Serialized =
   | SignedERC1155OrderStructSerialized;
 
 export type ECSignature = {
-  v: string | number;
-  r: string | Array<number>;
-  s: string | Array<number>;
+  v: number;
+  r: string;
+  s: string;
 };
 
 export type SignatureStruct = {
-  signatureType: number | string; // 2 for EIP-712
-  v: number | string;
-  r: string | Array<number>;
-  s: string | Array<number>;
+  signatureType: number; // 2 for EIP-712
+  v: number;
+  r: string;
+  s: string;
 };
 
 export type SignatureStructSerialized = {
   signatureType: number; // 2 for EIP-712
-  v: string;
+  v: number;
   r: string;
   s: string;
 };

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -41,7 +41,7 @@ export type ERC1155OrderStruct = {
 };
 
 export type ERC1155OrderStructSerialized = {
-  direction: string;
+  direction: number;
   maker: string;
   taker: string;
   expiry: string;

--- a/test/v4/collection-orders.test.ts
+++ b/test/v4/collection-orders.test.ts
@@ -97,8 +97,8 @@ describe('NFTSwapV4', () => {
     //   {
     //     fillOrderWithNativeTokenInsteadOfWrappedToken: false,
     //     tokenIdToSellForCollectionOrder: '11045',
-    //   },
-    //   { gasLimit: '500000' }
+    //   }
+    //   // { gasLimit: '500000' }
     // );
     // const txReceipt = await fillTx.wait();
     // console.log('erc721 fill tx', txReceipt.transactionHash);

--- a/test/v4/fees.test.ts
+++ b/test/v4/fees.test.ts
@@ -124,7 +124,7 @@ describe('NFTSwapV4', () => {
     // );
 
     // Uncomment to actually fill order
-    // const tx = await nftSwapperMaker.fillSignedOrder(signedOrder)//, undefined, { gasLimit: '500000'})
+    // const tx = await nftSwapperMaker.fillSignedOrder(signedOrder); //, undefined, { gasLimit: '500000'})
 
     // const txReceipt = await tx.wait();
     // expect(txReceipt.transactionHash).toBeTruthy();

--- a/test/v4/fees.test.ts
+++ b/test/v4/fees.test.ts
@@ -93,7 +93,7 @@ describe('NFTSwapV4', () => {
     )) as SignedERC721OrderStruct;
 
     expect(signedOrder.fees[0].recipient).toEqual(
-      '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34'
+      '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34'.toLowerCase()
     );
     // console.log('erc721 signatuee', signedOrder.signature);
     // expect(signedOrder.signature.signatureType.toString()).toEqual('2');


### PR DESCRIPTION
Standardizes and normalizes order when buildOrder is called, instead of having `BigNumberIsh` everywhere.

Easier for integrators to only handle `strings` (and a couple `number`s, nothing complex)