### PR TITLE
Expose NftSwapv4 types

### DIFF
--- a/src/sdk/common/types.ts
+++ b/src/sdk/common/types.ts
@@ -18,33 +18,6 @@ export interface BaseNftSwap {
   // checkIfOrderCanBeFilledWithNativeToken: Function;
 }
 
-// User facing
-export interface UserFacingERC20AssetDataSerialized {
-  tokenAddress: string;
-  type: 'ERC20';
-  amount: string;
-}
-
-export interface UserFacingERC721AssetDataSerialized {
-  tokenAddress: string;
-  tokenId: string;
-  type: 'ERC721';
-}
-/**
- * Mimic the erc721 duck type
- */
-export interface UserFacingERC1155AssetDataSerializedNormalizedSingle {
-  tokenAddress: string;
-  tokenId: string;
-  type: 'ERC1155';
-  amount?: string; // Will default to '1'
-}
-
-export type SwappableAsset =
-  | UserFacingERC20AssetDataSerialized
-  | UserFacingERC721AssetDataSerialized
-  | UserFacingERC1155AssetDataSerializedNormalizedSingle;
-
 /**
  * Approval status of an ERC20, ERC721, or ERC1155 asset/item.
  * The default approval spending address is the ExchangeProxy adapter specific to ERC type.

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -6,6 +6,7 @@ export * from './v3/types';
 export * from './v3/pure';
 export * from './v4/types';
 export * from './v4/enums';
+export * from './v4/constants';
 export * from '../utils/v3/asset-data';
 // Export contracts for advanced mode
 export * as ExchangeContract from '../contracts/ExchangeContract';

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -4,6 +4,8 @@ export * from './v4/NftSwapV4';
 export { NftSwapV3 as NftSwap } from './v3/NftSwapV3';
 export * from './v3/types';
 export * from './v3/pure';
+export * from './v4/types';
+export * from './v4/enums';
 export * from '../utils/v3/asset-data';
 // Export contracts for advanced mode
 export * as ExchangeContract from '../contracts/ExchangeContract';

--- a/src/sdk/v3/INftSwapV3.ts
+++ b/src/sdk/v3/INftSwapV3.ts
@@ -3,10 +3,10 @@ import type { ContractTransaction } from '@ethersproject/contracts';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type {
   Order,
-  OrderInfo,
-  OrderStatus,
+  OrderInfoV3,
+  OrderStatusV3,
   SignedOrder,
-  SigningOptions,
+  SigningOptionsV3,
   SwappableAsset,
   TypedData,
 } from './types';
@@ -33,7 +33,7 @@ export interface INftSwapV3 extends BaseNftSwap {
     order: Order,
     signerAddress: string,
     signer: Signer,
-    signingOptions?: Partial<SigningOptions>
+    signingOptions?: Partial<SigningOptionsV3>
   ) => Promise<SignedOrder>;
   buildOrder: (
     makerAssets: Array<SwappableAsset>,
@@ -64,9 +64,9 @@ export interface INftSwapV3 extends BaseNftSwap {
     timeoutInMs?: number,
     pollOrderStatusFrequencyInMs?: number,
     throwIfStatusOtherThanFillableOrFilled?: boolean
-  ) => Promise<OrderInfo | null>;
-  getOrderStatus: (order: Order) => Promise<OrderStatus>;
-  getOrderInfo: (order: Order) => Promise<OrderInfo>;
+  ) => Promise<OrderInfoV3 | null>;
+  getOrderStatus: (order: Order) => Promise<OrderStatusV3>;
+  getOrderInfo: (order: Order) => Promise<OrderInfoV3>;
   getOrderHash: (order: Order) => string;
   getTypedData: (
     chainId: number,

--- a/src/sdk/v3/pure.ts
+++ b/src/sdk/v3/pure.ts
@@ -37,18 +37,18 @@ import { UnexpectedAssetTypeError } from '../error';
 import {
   AdditionalOrderConfig,
   AssetProxyId,
-  AvailableSignatureTypes,
+  AvailableSignatureTypesV3,
   EIP712_TYPES,
   ERC1155AssetDataSerialized,
   ERC20AssetDataSerialized,
   ERC721AssetDataSerialized,
   MultiAssetDataSerializedRecursivelyDecoded,
   Order,
-  OrderInfo,
-  OrderStatus,
+  OrderInfoV3,
+  OrderStatusV3,
   SerializedAvailableAssetDataTypesDecoded,
   SignedOrder,
-  SigningOptions,
+  SigningOptionsV3,
   SwappableAsset,
   UserFacingERC1155AssetDataSerializedNormalizedSingle,
   UserFacingERC20AssetDataSerialized,
@@ -74,17 +74,17 @@ export const cancelOrder = (
 export const getOrderInfo = async (
   exchangeContract: ExchangeContract,
   order: Order
-): Promise<OrderInfo> => {
+): Promise<OrderInfoV3> => {
   const orderInfo = await exchangeContract.getOrderInfo(order);
-  return orderInfo as OrderInfo;
+  return orderInfo as OrderInfoV3;
 };
 
 export const getOrderStatus = async (
   exchangeContract: ExchangeContract,
   order: Order
-): Promise<OrderStatus> => {
+): Promise<OrderStatusV3> => {
   const orderInfo = await exchangeContract.getOrderInfo(order);
-  return orderInfo.orderStatus as OrderStatus;
+  return orderInfo.orderStatus as OrderStatusV3;
 };
 
 export const cancelOrders = (
@@ -201,10 +201,10 @@ export const signOrder = async (
   provider: Provider,
   chainId: number,
   exchangeContractAddress: string,
-  signingOptions?: Partial<SigningOptions>
+  signingOptions?: Partial<SigningOptionsV3>
 ): Promise<SignedOrder> => {
   try {
-    let method: AvailableSignatureTypes = 'eoa';
+    let method: AvailableSignatureTypesV3 = 'eoa';
     // If we have any specific signature type overrides, prefer those
     if (signingOptions?.signatureType === 'eip1271') {
       method = 'eip1271';

--- a/src/sdk/v3/types.ts
+++ b/src/sdk/v3/types.ts
@@ -3,7 +3,7 @@ import type { Bytes } from '@ethersproject/bytes';
 
 export type BigNumberish = BigNumber | Bytes | bigint | string | number;
 
-export interface AddressesForChain {
+export interface AddressesForChainV3 {
   exchange: string;
   erc20Proxy: string;
   erc721Proxy: string;
@@ -14,7 +14,7 @@ export interface AddressesForChain {
 }
 
 export type ContractAddresses = {
-  [chainId: string]: AddressesForChain;
+  [chainId: string]: AddressesForChainV3;
 };
 
 export interface Order {
@@ -60,7 +60,7 @@ export enum AssetProxyId {
   ERC20Bridge = '0xdc1600f3',
 }
 
-export enum SupportedChainIds {
+export enum SupportedChainIdsV3 {
   Mainnet = 1,
   Ropsten = 3,
   Rinkeby = 4,
@@ -72,13 +72,13 @@ export enum SupportedChainIds {
   Avalanche = 43114,
 }
 
-export interface OrderInfo {
-  orderStatus: OrderStatus;
+export interface OrderInfoV3 {
+  orderStatus: OrderStatusV3;
   orderHash: string;
   orderTakerAssetFilledAmount: BigNumber;
 }
 
-export enum OrderStatus {
+export enum OrderStatusV3 {
   Invalid = 0,
   InvalidMakerAssetAmount,
   InvalidTakerAssetAmount,
@@ -487,9 +487,9 @@ export enum RevertReason {
   OnlyCallableByWallet = 'ONLY_CALLABLE_BY_WALLET',
 }
 
-export type AvailableSignatureTypes = 'eoa' | 'eip1271';
+export type AvailableSignatureTypesV3 = 'eoa' | 'eip1271';
 
-export interface SigningOptions {
-  signatureType: AvailableSignatureTypes; // | 'autodetect' ? and remove autodetectSignatureType maybe?
+export interface SigningOptionsV3 {
+  signatureType: AvailableSignatureTypesV3; // | 'autodetect' ? and remove autodetectSignatureType maybe?
   autodetectSignatureType: boolean;
 }

--- a/src/sdk/v4/constants.ts
+++ b/src/sdk/v4/constants.ts
@@ -1,0 +1,33 @@
+export const EIP712_DOMAIN_PARAMETERS = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+];
+
+export const ERC721ORDER_STRUCT_ABI = [
+  { type: 'uint8', name: 'direction' },
+  { type: 'address', name: 'maker' },
+  { type: 'address', name: 'taker' },
+  { type: 'uint256', name: 'expiry' },
+  { type: 'uint256', name: 'nonce' },
+  { type: 'address', name: 'erc20Token' },
+  { type: 'uint256', name: 'erc20TokenAmount' },
+  { type: 'Fee[]', name: 'fees' },
+  { type: 'address', name: 'erc721Token' },
+  { type: 'uint256', name: 'erc721TokenId' },
+  { type: 'Property[]', name: 'erc721TokenProperties' },
+];
+
+export const FEE_ABI = [
+  { type: 'address', name: 'recipient' },
+  { type: 'uint256', name: 'amount' },
+  { type: 'bytes', name: 'feeData' },
+];
+
+export const PROPERTY_ABI = [
+  { type: 'address', name: 'propertyValidator' },
+  { type: 'bytes', name: 'propertyData' },
+];
+
+export const ERC721STRUCT_NAME = 'ERC721Order';

--- a/src/sdk/v4/enums.ts
+++ b/src/sdk/v4/enums.ts
@@ -1,0 +1,20 @@
+export enum TradeDirection {
+  SellNFT = 0,
+  BuyNFT = 1,
+}
+
+export enum OrderStatusV4 {
+  Invalid = 0,
+  Fillable = 1,
+  Unfillable = 2,
+  Expired = 3,
+}
+
+export type DirectionMap = {
+  [key in TradeDirection]: 'buy' | 'sell' | undefined;
+};
+
+export const DIRECTION_MAPPING: DirectionMap = {
+  [TradeDirection.BuyNFT]: 'buy',
+  [TradeDirection.SellNFT]: 'sell',
+};

--- a/src/sdk/v4/properties.ts
+++ b/src/sdk/v4/properties.ts
@@ -1,0 +1,11 @@
+import { NULL_ADDRESS } from '../../utils/eth';
+import { PropertyStruct } from './types';
+
+/**
+ * Contract-based orders property validator.
+ * Add this to your order's tokenProperties to make it a collection order
+ */
+export const CONTRACT_ORDER_VALIDATOR: PropertyStruct = {
+  propertyValidator: NULL_ADDRESS,
+  propertyData: [],
+};

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -204,15 +204,47 @@ export interface BuildOrderAdditionalConfig {
   nonce: BigNumberish;
 }
 
-export type AvailableSignatureTypes = 'eoa'; // No EIP-1271 / preSign yet (soon though)
+export type AvailableSignatureTypesV4 = 'eoa'; // No EIP-1271 / preSign yet (soon though)
 
-export interface SigningOptions {
-  signatureType: AvailableSignatureTypes; // | 'autodetect' ? and remove autodetectSignatureType maybe?
+export interface SigningOptionsV4 {
+  signatureType: AvailableSignatureTypesV4; // | 'autodetect' ? and remove autodetectSignatureType maybe?
   autodetectSignatureType: boolean;
 }
 
 // Typings for addresses.json file
-export interface AddressesForChain {
+export interface AddressesForChainV4 {
   exchange: string;
   wrappedNativeToken: string;
 }
+
+// User facing
+export interface UserFacingERC20AssetDataSerializedV4 {
+  tokenAddress: string;
+  type: 'ERC20';
+  amount: string;
+}
+
+export interface UserFacingERC721AssetDataSerializedV4 {
+  tokenAddress: string;
+  tokenId: string;
+  type: 'ERC721';
+}
+
+/**
+ * Mimic the erc721 duck type
+ */
+export interface UserFacingERC1155AssetDataSerializedV4 {
+  tokenAddress: string;
+  tokenId: string;
+  type: 'ERC1155';
+  amount?: string; // Will default to '1'
+}
+
+export type SwappableNftV4 =
+  | UserFacingERC721AssetDataSerializedV4
+  | UserFacingERC1155AssetDataSerializedV4;
+
+export type SwappableAssetV4 =
+  | UserFacingERC20AssetDataSerializedV4
+  | UserFacingERC721AssetDataSerializedV4
+  | UserFacingERC1155AssetDataSerializedV4;

--- a/src/utils/v3/default-addresses.ts
+++ b/src/utils/v3/default-addresses.ts
@@ -1,6 +1,6 @@
 import { UnsupportedChainId, UnexpectedAssetTypeError } from '../../sdk/error';
 import type {
-  AddressesForChain,
+  AddressesForChainV3,
   ContractAddresses,
   SupportedTokenTypes,
 } from '../../sdk/v3/types';
@@ -9,10 +9,10 @@ import defaultAddresses from '../../sdk/v3/addresses.json';
 const getZeroExAddressesForChain = (
   chainId: number,
   addresses: ContractAddresses = defaultAddresses
-): AddressesForChain | undefined => {
+): AddressesForChainV3 | undefined => {
   const chainIdString = chainId.toString(10);
-  const maybeAddressesForChain: AddressesForChain | undefined = (
-    addresses as { [key: string]: AddressesForChain }
+  const maybeAddressesForChain: AddressesForChainV3 | undefined = (
+    addresses as { [key: string]: AddressesForChainV3 }
   )[chainIdString];
   return maybeAddressesForChain;
 };

--- a/src/utils/v3/gas-buffer.ts
+++ b/src/utils/v3/gas-buffer.ts
@@ -1,9 +1,9 @@
-import { SupportedChainIds } from '../../sdk/v3/types';
+import { SupportedChainIdsV3 } from '../../sdk/v3/types';
 
 const DEFAUTLT_GAS_BUFFER_MULTIPLES: { [chainId: number]: number } = {
-  [SupportedChainIds.Polygon]: 1.5,
-  [SupportedChainIds.PolygonMumbai]: 1.5,
-  [SupportedChainIds.Kovan]: 1.5,
+  [SupportedChainIdsV3.Polygon]: 1.5,
+  [SupportedChainIdsV3.PolygonMumbai]: 1.5,
+  [SupportedChainIdsV3.Kovan]: 1.5,
 };
 
 export { DEFAUTLT_GAS_BUFFER_MULTIPLES };

--- a/test/v3/forwarder-swap.test.ts
+++ b/test/v3/forwarder-swap.test.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import { parseEther } from 'ethers/lib/utils';
 import { NftSwap, SwappableAsset } from '../../src';
 import { normalizeOrder } from '../../src/utils/v3/order';
 

--- a/test/v3/multi-asset-swap.test.ts
+++ b/test/v3/multi-asset-swap.test.ts
@@ -6,7 +6,7 @@ import {
   estimateGasForFillOrder,
   MultiAssetDataSerializedRecursivelyDecoded,
   NftSwap,
-  SupportedChainIds,
+  SupportedChainIdsV3,
   SwappableAsset,
 } from '../../src';
 import { DEFAUTLT_GAS_BUFFER_MULTIPLES } from '../../src/utils/v3/gas-buffer';

--- a/test/v3/mumbai-swap.test.ts
+++ b/test/v3/mumbai-swap.test.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import {
   estimateGasForFillOrder,
   NftSwap,
-  SupportedChainIds,
+  SupportedChainIdsV3,
   SwappableAsset,
 } from '../../src';
 import { DEFAUTLT_GAS_BUFFER_MULTIPLES } from '../../src/utils/v3/gas-buffer';

--- a/test/v3/order-status.test.ts
+++ b/test/v3/order-status.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { NftSwap, SwappableAsset } from '../../src';
-import { OrderStatus } from '../../src/sdk/v3/types';
+import { OrderStatusV3 } from '../../src/sdk/v3/types';
 import { normalizeOrder } from '../../src/utils/v3/order';
 
 jest.setTimeout(60 * 1000);
@@ -95,7 +95,7 @@ describe('NFTSwap', () => {
 
     const orderInfo = await nftSwapperMaker.getOrderInfo(normalizedOrder);
 
-    expect(orderInfo.orderStatus).toBe(OrderStatus.Fillable);
+    expect(orderInfo.orderStatus).toBe(OrderStatusV3.Fillable);
 
     const signedOrder = await nftSwapperMaker.signOrder(
       normalizedOrder,

--- a/test/v4/collection-orders.test.ts
+++ b/test/v4/collection-orders.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
 
-import { SwappableAsset } from '../../src/sdk/v4/pure';
+import { SwappableAssetV4 } from '../../src/sdk/v4/types';
 import { SignedERC721OrderStruct } from '../../src/sdk/v4/types';
 import { NULL_ADDRESS } from '../../src/utils/eth';
 
@@ -36,13 +36,13 @@ const nftSwapperMaker = new NftSwapV4(
 );
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
-const MAKER_ASSET: SwappableAsset = {
+const MAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
   amount: '100000000000', // 1 USDC
 };
 
-const TAKER_ASSET: SwappableAsset = {
+const TAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
   tokenId: '1',

--- a/test/v4/fees.test.ts
+++ b/test/v4/fees.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
 
-import { SwappableAsset } from '../../src/sdk/v4/pure';
+import { SwappableAssetV4 } from '../../src/sdk/v4/types';
 import { SignedERC721OrderStruct } from '../../src/sdk/v4/types';
 import { NULL_ADDRESS } from '../../src/utils/eth';
 
@@ -36,13 +36,13 @@ const nftSwapperMaker = new NftSwapV4(
 );
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
-const MAKER_ASSET: SwappableAsset = {
+const MAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
   amount: '420000000000000', // 1 USDC
 };
 
-const TAKER_ASSET: SwappableAsset = {
+const TAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
   tokenId: '11045',

--- a/test/v4/orderbook.test.ts
+++ b/test/v4/orderbook.test.ts
@@ -6,7 +6,7 @@ import {
   postOrderToOrderbook,
   searchOrderbook,
 } from '../../src/sdk/v4/orderbook';
-import { SwappableAsset } from '../../src/sdk/v4/pure';
+import { SwappableAssetV4 } from '../../src/sdk';
 
 jest.setTimeout(90 * 1000);
 
@@ -39,12 +39,12 @@ const nftSwapperMaker = new NftSwapV4(
 );
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
-const TAKER_ASSET: SwappableAsset = {
+const TAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
   amount: '100000000000', // 1 USDC
 };
-const MAKER_ASSET: SwappableAsset = {
+const MAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
   tokenId: '11045',

--- a/test/v4/sell-nft-no-approval.test.ts
+++ b/test/v4/sell-nft-no-approval.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
 
-import { SwappableAsset } from '../../src/sdk/v4/pure';
+import { SwappableAssetV4 } from '../../src/sdk/v4/types';
 import { SignedERC721OrderStruct } from '../../src/sdk/v4/types';
 import { NULL_ADDRESS } from '../../src/utils/eth';
 
@@ -36,13 +36,13 @@ const nftSwapperMaker = new NftSwapV4(
 );
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
-const NFT_ASSET: SwappableAsset = {
+const NFT_ASSET: SwappableAssetV4 = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
   tokenId: '11045',
 };
 
-const ERC20_ASSET: SwappableAsset = {
+const ERC20_ASSET: SwappableAssetV4 = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
   amount: '420000000000000', // 1 USDC

--- a/test/v4/smoke-test-swap.test.ts
+++ b/test/v4/smoke-test-swap.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
 
-import { SwappableAsset } from '../../src/sdk/v4/pure';
+import { SwappableAssetV4 } from '../../src/sdk/v4/types';
 
 jest.setTimeout(90 * 1000);
 
@@ -34,12 +34,12 @@ const nftSwapperMaker = new NftSwapV4(
 );
 // const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
 
-const TAKER_ASSET: SwappableAsset = {
+const TAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC20',
   tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
   amount: '100000000000', // 1 USDC
 };
-const MAKER_ASSET: SwappableAsset = {
+const MAKER_ASSET: SwappableAssetV4 = {
   type: 'ERC721',
   tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
   tokenId: '11045',


### PR DESCRIPTION
Rejiggers types and exports all useful interfaces

This is technically a breaking change since we're renaming some interfaces.

If you find this PR: Just add V3 or V4 to the end of the type. e.g. `SwappableAsset `-> `SwappableAssetV4`