### PR TITLE
Fixes V3 verifyOrderSignature signature to validate correctly

### DIFF
--- a/test/v3/signatures.test.ts
+++ b/test/v3/signatures.test.ts
@@ -1,4 +1,10 @@
-import { hexDataLength, hexDataSlice } from '@ethersproject/bytes';
+import {
+  hexConcat,
+  hexDataLength,
+  hexDataSlice,
+  joinSignature,
+  splitSignature,
+} from '@ethersproject/bytes';
 import { ethers } from 'ethers';
 import { NftSwap, SwappableAsset } from '../../src';
 import {
@@ -76,24 +82,13 @@ describe('NFTSwap', () => {
       MAKER_WALLET_ADDRESS.toLowerCase()
     );
 
-    const rawSignature = await signOrderWithEoaWallet(
-      order,
-      nftSwapperMaker.signer as any,
-      nftSwapperMaker.chainId,
-      nftSwapperMaker.exchangeContractAddress
-    );
-
-    const length = hexDataLength(signedOrder.signature);
-    const signatureType = hexDataSlice(signedOrder.signature, length - 1);
-
-    expect(signatureType).toBe('0x02');
-
     const isValidSignature = await verifyOrderSignature(
       normalizedSignedOrder,
-      rawSignature,
+      signedOrder.signature,
       80001,
       nftSwapperMaker.exchangeContract.address
     );
+
     expect(isValidSignature).toBe(true);
   });
 });


### PR DESCRIPTION
Sometimes (just due to how signatures are derived between 0x orders and other standards), signatures would not validate successfully when calling `verifyOrderSignature`. This fixes that to use a standard way of deriving a signature that can be passed to verify the typed data (since you can't pass a 0x order signature directly to a verifyTypedData signature)