### PR TITLE
Enables multichain support for 0x v4 in the Swap SDK

### DIFF
--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -6,6 +6,7 @@ import type {
 import type { BigNumberish, ContractTransaction } from 'ethers';
 import { Interface } from '@ethersproject/abi';
 import invariant from 'tiny-invariant';
+import warning from 'tiny-warning';
 import {
   ERC1155__factory,
   ERC721__factory,
@@ -59,7 +60,22 @@ export enum SupportedChainIdsV4 {
   Mainnet = 1,
   Ropsten = 3,
   Ganache = 1337,
+  Polygon = 137,
+  BSC = 56,
+  Optimism = 10,
+  Fantom = 250,
+  Celo = 42220,
+  Avalance = 43114,
+  // Arbitrum = 42161, // soon
 }
+
+export const SupportedChainsForV4OrderbookStatusMonitoring = [
+  SupportedChainIdsV4.Ropsten,
+  SupportedChainIdsV4.Polygon,
+  SupportedChainIdsV4.Mainnet,
+  SupportedChainIdsV4.Optimism,
+  // SupportedChainIdsV4.Arbitrum,
+];
 
 export interface INftSwapV4 extends BaseNftSwap {
   signOrder: (
@@ -599,6 +615,13 @@ class NftSwapV4 implements INftSwapV4 {
     chainId: string,
     metadata?: Record<string, string>
   ) => {
+    const supportsMonitoring = SupportedChainsForV4OrderbookStatusMonitoring.includes(
+      parseInt(chainId)
+    );
+    warning(
+      supportsMonitoring,
+      `Chain ${chainId} does not support live orderbook status monitoring. Orders can be posted to be persisted, but status wont be monitored (e.g. updating status on a fill, cancel, or expiry.)`
+    );
     postOrderToOrderbook(signedOrder, chainId, metadata, {
       rootUrl: this.orderbookRootUrl,
     });

--- a/src/sdk/v4/addresses.json
+++ b/src/sdk/v4/addresses.json
@@ -11,6 +11,22 @@
     "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
     "wrappedNativeToken": "0xc778417e063141139fce010982780140aa0cd5ab"
   },
+  "10": {
+    "exchange": "0xdef1abe32c034e558cdd535791643c58a13acc10",
+    "wrappedNativeToken": "0x4200000000000000000000000000000000000006"
+  },
+  "250": {
+    "exchange": "0xdef189deaef76e379df891899eb5a00a94cbc250",
+    "wrappedNativeToken": "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83"
+  },
+  "42220": {
+    "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+    "wrappedNativeToken": "0x471EcE3750Da237f93B8E339c536989b8978a438"
+  },
+  "42161": {
+    "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+    "wrappedNativeToken": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1"
+  },
   "42": {
     "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
     "wrappedNativeToken": "0xd0a1e359811322d97991e03f863a0c30c2cf029c"


### PR DESCRIPTION
Adds Polygon, BSC, Optimism, Fantom, Celo and Avalanche support to the 0x v4 Swap SDK. 

Arbitrum will follow shortly.

Also includes a warning when using the orderbook on an unsupported chain.