### PR TITLE
allow search order params to be nullable

### DIFF
--- a/src/sdk/v4/orderbook.ts
+++ b/src/sdk/v4/orderbook.ts
@@ -77,14 +77,14 @@ const postOrderToOrderbook = async (
 };
 
 export interface SearchOrdersParams {
-  erc20Token: string;
-  nftTokenId: string;
-  nftToken: string;
-  nftType: string;
-  chainId: string;
-  maker: string;
-  taker: string;
-  nonce: string;
+  erc20Token?: string;
+  nftTokenId?: string;
+  nftToken?: string;
+  nftType?: string;
+  chainId?: string;
+  maker?: string;
+  taker?: string;
+  nonce?: string;
 }
 
 const searchOrderbook = async (


### PR DESCRIPTION
Right now the search order params interface requires all properties. This makes them nullable so you can only pass the ones you want.