### PR TITLE
Add validation guardrails around trying to bid with native token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.16.2",
+  "version": "0.17.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -383,6 +383,16 @@ class NftSwapV4 implements INftSwapV4 {
 
     const direction =
       sellOrBuyNft === 'sell' ? TradeDirection.SellNFT : TradeDirection.BuyNFT;
+
+    // Validate that a bid does not use ETH.
+    if (direction === TradeDirection.BuyNFT) {
+      if (erc20.tokenAddress.toLowerCase() === FAKE_ETH_ADDRESS) {
+        throw new Error(
+          'NFT Bids cannot use the native token (e.g. ETH). Please use the wrapped native token (e.g. WETH)'
+        );
+      }
+    }
+
     switch (nft.type) {
       // Build ERC721 order
       case 'ERC721':

--- a/src/sdk/v4/constants.ts
+++ b/src/sdk/v4/constants.ts
@@ -54,3 +54,6 @@ export const PROPERTY_ABI = [
   { type: 'address', name: 'propertyValidator' },
   { type: 'bytes', name: 'propertyData' },
 ];
+
+export const ETH_ADDRESS_AS_ERC20 =
+  '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';

--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -36,6 +36,7 @@ import {
   ERC1155ORDER_STRUCT_ABI,
   FEE_ABI,
   PROPERTY_ABI,
+  ETH_ADDRESS_AS_ERC20,
 } from './constants';
 import warning from 'tiny-warning';
 
@@ -111,6 +112,12 @@ export const getApprovalStatus = async (
 ): Promise<ApprovalStatus> => {
   switch (asset.type) {
     case 'ERC20':
+      // ETH (ERC20 representation) requires no approvals, we can shortcut here
+      if (asset.tokenAddress.toLowerCase() === ETH_ADDRESS_AS_ERC20) {
+        return {
+          contractApproved: true,
+        };
+      }
       const erc20 = ERC20__factory.connect(asset.tokenAddress, provider);
       const erc20AllowanceBigNumber: BigNumber = await erc20.allowance(
         walletAddress,

--- a/test/v4/order-validation.test.ts
+++ b/test/v4/order-validation.test.ts
@@ -1,0 +1,59 @@
+import { ethers } from 'ethers';
+import { ETH_ADDRESS_AS_ERC20 } from '../../src/sdk';
+import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
+import { SwappableAssetV4 } from '../../src/sdk/v4/types';
+
+jest.setTimeout(20 * 1000);
+
+const MAKER_WALLET_ADDRESS = '0xabc23F70Df4F45dD3Df4EC6DA6827CB05853eC9b';
+const MAKER_PRIVATE_KEY =
+  'fc5db508b0a52da8fbcac3ab698088715595f8de9cccf2467d51952eec564ec9';
+// NOTE(johnrjj) - NEVER use these private keys for anything of value, testnets only!
+
+const DAI_TOKEN_ADDRESS_TESTNET = '0x31f42841c2db5173425b5223809cf3a38fede360';
+const TEST_NFT_CONTRACT_ADDRESS = '0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b'; // https://ropsten.etherscan.io/token/0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b?a=0xabc23F70Df4F45dD3Df4EC6DA6827CB05853eC9b
+
+const RPC_TESTNET =
+  'https://eth-ropsten.alchemyapi.io/v2/is1WqyAFM1nNFFx2aCozhTep7IxHVNGo';
+
+const MAKER_WALLET = new ethers.Wallet(MAKER_PRIVATE_KEY);
+
+const PROVIDER = new ethers.providers.StaticJsonRpcProvider(RPC_TESTNET);
+
+const MAKER_SIGNER = MAKER_WALLET.connect(PROVIDER);
+
+const ROPSTEN_CHAIN_ID = 3;
+
+const nftSwapperMaker = new NftSwapV4(
+  MAKER_SIGNER as any,
+  MAKER_SIGNER,
+  ROPSTEN_CHAIN_ID
+);
+
+const ETH_AS_BID_ASSET_NOT_ALLOWED: SwappableAssetV4 = {
+  type: 'ERC20',
+  tokenAddress: ETH_ADDRESS_AS_ERC20,
+  amount: '100000000000', // 1 USDC
+};
+const NFT: SwappableAssetV4 = {
+  type: 'ERC721',
+  tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
+  tokenId: '11045',
+};
+
+describe('NFTSwapV4', () => {
+  it('V4 NFT bids should throw if bidding with ETH directly.', async () => {
+    // This is not allowed and should throw
+    const buildNftBidWithNativeToken = () =>
+      nftSwapperMaker.buildOrder(
+        ETH_AS_BID_ASSET_NOT_ALLOWED,
+        NFT,
+        MAKER_WALLET_ADDRESS
+      );
+
+    // Use WETH instead!
+    expect(buildNftBidWithNativeToken).toThrowError(
+      'NFT Bids cannot use the native token (e.g. ETH). Please use the wrapped native token (e.g. WETH)'
+    );
+  });
+});


### PR DESCRIPTION
Bids for NFTs cannot technically be bid in native token (e.g. ETH) and need to use wrapped token (e.g. WETH) (since ETH cannot be moved via smart contracts like an ERC20).

Fills can still be filled in ETH (and the bid WETH can be converted just-in-time during fill to ETH).