### PR TITLE
Order validation helper functions for v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "size-limit": [
     {
       "path": "dist/nft-swap-sdk.cjs.production.min.js",
-      "limit": "250 KB"
+      "limit": "275 KB"
     },
     {
       "path": "dist/nft-swap-sdk.esm.js",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/lodash": "^4.14.181",
     "@types/uuid": "^8.3.4",
     "husky": "^7.0.2",
-    "prettier": "^2.6.1",
+    "prettier": "^2.6.2",
     "size-limit": "7.0.8",
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -907,7 +907,7 @@ class NftSwapV4 implements INftSwapV4 {
     }
   };
 
-  // todo: consolidate
+  // TODO(johnrjj) Consolidate w/ checkOrderCanBeFilledMakerSide
   checkOrderCanBeFilledTakerSide = async (
     order: NftOrderV4,
     takerWalletAddress: string

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -61,6 +61,7 @@ import { DIRECTION_MAPPING, OrderStatusV4, TradeDirection } from './enums';
 import { CONTRACT_ORDER_VALIDATOR } from './properties';
 import { getWrappedNativeToken } from '../../utils/addresses';
 import { ETH_ADDRESS_AS_ERC20 } from './constants';
+import { ZERO_AMOUNT } from '../../utils/eth';
 
 export enum SupportedChainIdsV4 {
   Mainnet = 1,
@@ -970,6 +971,25 @@ class NftSwapV4 implements INftSwapV4 {
       hasBalance,
       canOrderBeFilled,
     };
+  };
+
+  /**
+   * Calculates total order cost. 
+   * In 0x v4, fees are additive (i.e. they are not deducted from the order amount, but added on top of)
+   * @param order A 0x v4 order;
+   * @returns BigNumber of order total cost in erc20 unit amount
+   */
+  getErc20TotalIncludingFees = (order: NftOrderV4): BigNumber => {
+    const fees = order.fees;
+    // In 0x v4, fees are additive (not included in the original erc20 amount)
+    let feesTotal = ZERO_AMOUNT;
+    fees.forEach((fee) => {
+      feesTotal = ZERO_AMOUNT.add(BigNumber.from(fee.amount));
+    });
+    const orderTotalCost = BigNumber.from(order.erc20TokenAmount).add(
+      feesTotal
+    );
+    return orderTotalCost;
   };
 }
 

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -703,6 +703,50 @@ class NftSwapV4 implements INftSwapV4 {
       'Only ERC721 Orders are currently supported for matching. Please ensure both the sellOrder and buyOrder are ERC721 orders'
     );
   };
+  getTakerAsset = (order: NftOrderV4): SwappableAssetV4 => {
+    // return {
+    //   tokenAddress: '',
+    //   tokenId: ''
+    // }
+  };
+
+  getMakerAsset = (order: NftOrderV4): SwappableAssetV4 => {
+    // return {
+    //   tokenAddress: '',
+    //   tokenId: ''
+    // }
+  };
+
+  // todo: consolidate
+  // todo: use these to power validation for the api
+  checkOrderCanBeFilledMakerSide = (order: NftOrderV4) => {};
+
+  checkOrderCanBeFilledTakerSide = (
+    order: NftOrderV4,
+    override?: VerifyOrderOptionsOverrides
+  ) => {
+    const shouldLoadApprovalStatus = override?.verifyApproval ?? true;
+    const shouldLoadBalance = override?.verifyBalance ?? true;
+
+    const direction = parseInt(order.direction.toString(10));
+    if (direction === TradeDirection.SellNFT) {
+      if ('erc721Token' in order) {
+        this.loadApprovalStatus();
+
+        const { erc721Token, erc721TokenId } = order;
+
+        // TODO(johnrjj) - More validation here before we match on-chain
+      } else if ('erc1155Token' in order) {
+        const { erc1155TokenAmount, erc1155Token, erc1155TokenId } = order;
+      }
+    } else if (direction === TradeDirection.BuyNFT) {
+    }
+  };
+}
+
+interface VerifyOrderOptionsOverrides {
+  verifyApproval?: boolean;
+  verifyBalance: boolean;
 }
 
 export { NftSwapV4 };

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -974,7 +974,7 @@ class NftSwapV4 implements INftSwapV4 {
   };
 
   /**
-   * Calculates total order cost. 
+   * Calculates total order cost.
    * In 0x v4, fees are additive (i.e. they are not deducted from the order amount, but added on top of)
    * @param order A 0x v4 order;
    * @returns BigNumber of order total cost in erc20 unit amount

--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -860,17 +860,23 @@ class NftSwapV4 implements INftSwapV4 {
    * @param signedOrder A 0x v4 signed order to validate signature for
    * @returns
    */
-  validateSignature = async (signedOrder: SignedNftOrderV4) => {
+  validateSignature = async (
+    signedOrder: SignedNftOrderV4
+  ): Promise<boolean> => {
     if ('erc721Token' in signedOrder) {
-      return this.exchangeProxy.validateERC721OrderSignature(
+      // Validate functions on-chain return void if successful
+      await this.exchangeProxy.validateERC721OrderSignature(
         signedOrder,
         signedOrder.signature
       );
+      return true;
     } else if ('erc1155Token' in signedOrder) {
-      return this.exchangeProxy.validateERC1155OrderSignature(
+      // Validate functions on-chain return void if successful
+      await this.exchangeProxy.validateERC1155OrderSignature(
         signedOrder,
         signedOrder.signature
       );
+      return true;
     } else {
       throw new Error('Unknown order type (not ERC721 or ERC1155)');
     }

--- a/src/sdk/v4/enums.ts
+++ b/src/sdk/v4/enums.ts
@@ -1,5 +1,11 @@
 export enum TradeDirection {
+  /**
+   * Sell orders are orders where direction is set to TradeDirection.SELL_NFT, which indicates that a maker wishes to sell an ERC721 token that they possess.
+   */
   SellNFT = 0,
+  /**
+   * Buy orders are where direction is set to TradeDirection.BUY_NFT, which indicates that a maker wishes to buy an ERC721 token that they do not possess.
+   */
   BuyNFT = 1,
 }
 
@@ -14,6 +20,10 @@ export type DirectionMap = {
   [key in TradeDirection]: 'buy' | 'sell' | undefined;
 };
 
+/**
+ * Buy orders are where direction is set to TradeDirection.BUY_NFT, which indicates that a maker wishes to buy an ERC721 token that they do not possess.
+ * Sell orders are orders where direction is set to TradeDirection.SELL_NFT, which indicates that a maker wishes to sell an ERC721 token that they possess.
+ */
 export const DIRECTION_MAPPING: DirectionMap = {
   [TradeDirection.BuyNFT]: 'buy',
   [TradeDirection.SellNFT]: 'sell',

--- a/src/sdk/v4/pure.ts
+++ b/src/sdk/v4/pure.ts
@@ -283,7 +283,7 @@ export function parseRawSignature(rawSignature: string): ECSignature {
   };
 }
 
-export const INFINITE_TIMESTAMP_SEC = BigNumber.from(2524604400);
+export const INFINITE_EXPIRATION_TIMESTAMP_SEC = BigNumber.from(2524604400);
 
 export const generateErc721Order = (
   nft: UserFacingERC721AssetDataSerializedV4,
@@ -313,7 +313,7 @@ export const generateErc721Order = (
       }) ?? [],
     expiry: orderData.expiry
       ? getUnixTime(orderData.expiry).toString()
-      : INFINITE_TIMESTAMP_SEC.toString(),
+      : INFINITE_EXPIRATION_TIMESTAMP_SEC.toString(),
     nonce: orderData.nonce?.toString() ?? generateRandomNonce(),
     taker: orderData.taker?.toLowerCase() ?? NULL_ADDRESS,
   };
@@ -330,7 +330,7 @@ export const generateErc1155Order = (
     erc1155Token: nft.tokenAddress.toLowerCase(),
     erc1155TokenId: nft.tokenId,
     erc1155TokenAmount: nft.amount ?? '1',
-    direction: parseInt(orderData.direction.toString()), // KLUDGE(johnrjj) - There's some footgun here when only doing orderData.direction.toString(), need to parseInt it
+    direction: parseInt(orderData.direction.toString(10)), // KLUDGE(johnrjj) - There's some footgun here when only doing orderData.direction.toString(), need to parseInt it
     erc20Token: erc20.tokenAddress.toLowerCase(),
     erc20TokenAmount: erc20.amount,
     maker: orderData.maker.toLowerCase(),
@@ -350,7 +350,7 @@ export const generateErc1155Order = (
       }) ?? [],
     expiry: orderData.expiry
       ? getUnixTime(orderData.expiry).toString()
-      : INFINITE_TIMESTAMP_SEC.toString(),
+      : INFINITE_EXPIRATION_TIMESTAMP_SEC.toString(),
     nonce: orderData.nonce?.toString() ?? generateRandomNonce(),
     taker: orderData.taker?.toLowerCase() ?? NULL_ADDRESS,
   };

--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -181,6 +181,7 @@ export type SignatureStructSerialized = {
 export interface ApprovalOverrides {
   signer: Signer;
   approve: boolean;
+  approvalOnlyTokenIdIfErc721: boolean;
   exchangeContractAddress: string;
   chainId: number;
 }
@@ -248,3 +249,8 @@ export type SwappableAssetV4 =
   | UserFacingERC20AssetDataSerializedV4
   | UserFacingERC721AssetDataSerializedV4
   | UserFacingERC1155AssetDataSerializedV4;
+
+export interface VerifyOrderOptionsOverrides {
+  verifyApproval?: boolean;
+  verifyBalance?: boolean;
+}

--- a/test/v4/fees.test.ts
+++ b/test/v4/fees.test.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
 
 import { SwappableAssetV4 } from '../../src/sdk/v4/types';
@@ -95,6 +95,16 @@ describe('NFTSwapV4', () => {
     expect(signedOrder.fees[0].recipient).toEqual(
       '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34'.toLowerCase()
     );
+
+    // Ensure getErc20TotalIncludingFees helper function works properly w/ fees.
+    const total = nftSwapperMaker
+      .getErc20TotalIncludingFees(signedOrder)
+      .toString();
+    const handCountedTotal = BigNumber.from(signedOrder.erc20TokenAmount).add(
+      BigNumber.from(signedOrder.fees[0].amount)
+    );
+    expect(total).toBe(handCountedTotal.toString());
+
     // console.log('erc721 signatuee', signedOrder.signature);
     // expect(signedOrder.signature.signatureType.toString()).toEqual('2');
 

--- a/test/v4/utils.test.ts
+++ b/test/v4/utils.test.ts
@@ -92,6 +92,11 @@ describe('NFTSwapV4', () => {
       v4Erc721SignedOrder.maker
     );
     expect(makerApprovalStatus.contractApproved).toBe(true);
+
+    const isSignatureValid = await nftSwapperMaker.validateSignature(
+      v4Erc721SignedOrder
+    );
+    expect(isSignatureValid).toBe(true);
   });
 
   it('utility functions on class work properly with erc721 buy order', async () => {
@@ -138,5 +143,10 @@ describe('NFTSwapV4', () => {
       v4Erc721SignedOrder.maker
     );
     expect(makerApprovalStatus.contractApproved).toBe(true);
+
+    const isSignatureValid = await nftSwapperMaker.validateSignature(
+      v4Erc721SignedOrder
+    );
+    expect(isSignatureValid).toBe(true);
   });
 });

--- a/test/v4/utils.test.ts
+++ b/test/v4/utils.test.ts
@@ -1,0 +1,142 @@
+import { BigNumber, ethers } from 'ethers';
+import { NftSwapV4 } from '../../src/sdk/v4/NftSwapV4';
+
+import {
+  SignedERC721OrderStruct,
+  SwappableAssetV4,
+} from '../../src/sdk/v4/types';
+
+jest.setTimeout(120 * 1000);
+
+const MAKER_WALLET_ADDRESS = '0xabc23F70Df4F45dD3Df4EC6DA6827CB05853eC9b';
+const MAKER_PRIVATE_KEY =
+  'fc5db508b0a52da8fbcac3ab698088715595f8de9cccf2467d51952eec564ec9';
+// NOTE(johnrjj) - NEVER use these private keys for anything of value, testnets only!
+
+const DAI_TOKEN_ADDRESS_TESTNET = '0x31f42841c2db5173425b5223809cf3a38fede360';
+const TEST_NFT_CONTRACT_ADDRESS = '0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b'; // https://ropsten.etherscan.io/token/0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b?a=0xabc23F70Df4F45dD3Df4EC6DA6827CB05853eC9b
+
+const RPC_TESTNET =
+  'https://eth-ropsten.alchemyapi.io/v2/is1WqyAFM1nNFFx2aCozhTep7IxHVNGo';
+
+const MAKER_WALLET = new ethers.Wallet(MAKER_PRIVATE_KEY);
+// const TAKER_WALLET = new ethers.Wallet(TAKER_PRIVATE_KEY);
+
+const PROVIDER = new ethers.providers.StaticJsonRpcProvider(RPC_TESTNET);
+
+const MAKER_SIGNER = MAKER_WALLET.connect(PROVIDER);
+// const TAKER_PROVIDER = TAKER_WALLET.connect(PROVIDER);
+
+const ROPSTEN_CHAIN_ID = 3;
+
+const nftSwapperMaker = new NftSwapV4(
+  MAKER_SIGNER as any,
+  MAKER_SIGNER,
+  ROPSTEN_CHAIN_ID
+);
+// const nftSwapperTaker = new NftSwap(TAKER_PROVIDER as any, 4);
+
+const ERC20_ASSET: SwappableAssetV4 = {
+  type: 'ERC20',
+  tokenAddress: DAI_TOKEN_ADDRESS_TESTNET,
+  amount: '100000000000', // 1 USDC
+};
+const NFT_ASSET: SwappableAssetV4 = {
+  type: 'ERC721',
+  tokenAddress: TEST_NFT_CONTRACT_ADDRESS,
+  tokenId: '11045',
+};
+
+describe('NFTSwapV4', () => {
+  it('utility functions on class work properly with erc721 sell order', async () => {
+    // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
+    const v4Erc721Order = nftSwapperMaker.buildOrder(
+      NFT_ASSET,
+      ERC20_ASSET,
+      MAKER_WALLET_ADDRESS,
+      {
+        fees: [
+          {
+            amount: '6900000000000',
+            recipient: '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34',
+          },
+        ],
+      }
+    );
+
+    const v4Erc721SignedOrder = await nftSwapperMaker.signOrder(v4Erc721Order);
+
+    // Ensure getErc20TotalIncludingFees helper function works properly w/ fees.
+    const total = nftSwapperMaker
+      .getErc20TotalIncludingFees(v4Erc721SignedOrder)
+      .toString();
+    const handCountedTotal = BigNumber.from(
+      v4Erc721SignedOrder.erc20TokenAmount
+    ).add(BigNumber.from(v4Erc721SignedOrder.fees[0].amount));
+    expect(total).toBe(handCountedTotal.toString());
+
+    const makerAsset = nftSwapperMaker.getMakerAsset(v4Erc721SignedOrder);
+    expect(makerAsset).toEqual(NFT_ASSET);
+
+    const takerAsset = nftSwapperMaker.getTakerAsset(v4Erc721SignedOrder);
+    expect(takerAsset).toEqual(ERC20_ASSET);
+
+    const makerBalance = await nftSwapperMaker.fetchBalanceForAsset(
+      makerAsset,
+      v4Erc721SignedOrder.maker
+    );
+    expect(makerBalance.gt(0)).toBe(true);
+
+    const makerApprovalStatus = await nftSwapperMaker.loadApprovalStatus(
+      makerAsset,
+      v4Erc721SignedOrder.maker
+    );
+    expect(makerApprovalStatus.contractApproved).toBe(true);
+  });
+
+  it('utility functions on class work properly with erc721 buy order', async () => {
+    // NOTE(johnrjj) - Assumes USDC and DAI are already approved w/ the ExchangeProxy
+    const v4Erc721Order = nftSwapperMaker.buildOrder(
+      ERC20_ASSET,
+      NFT_ASSET,
+      MAKER_WALLET_ADDRESS,
+      {
+        fees: [
+          {
+            amount: '6900000000000',
+            recipient: '0xaaa1388cD71e88Ae3D8432f16bed3c603a58aD34',
+          },
+        ],
+      }
+    );
+
+    const v4Erc721SignedOrder = await nftSwapperMaker.signOrder(v4Erc721Order);
+
+    // Ensure getErc20TotalIncludingFees helper function works properly w/ fees.
+    const total = nftSwapperMaker
+      .getErc20TotalIncludingFees(v4Erc721SignedOrder)
+      .toString();
+    const handCountedTotal = BigNumber.from(
+      v4Erc721SignedOrder.erc20TokenAmount
+    ).add(BigNumber.from(v4Erc721SignedOrder.fees[0].amount));
+    expect(total).toBe(handCountedTotal.toString());
+
+    const makerAsset = nftSwapperMaker.getMakerAsset(v4Erc721SignedOrder);
+    expect(makerAsset).toEqual(ERC20_ASSET);
+
+    const takerAsset = nftSwapperMaker.getTakerAsset(v4Erc721SignedOrder);
+    expect(takerAsset).toEqual(NFT_ASSET);
+
+    const makerBalance = await nftSwapperMaker.fetchBalanceForAsset(
+      makerAsset,
+      v4Erc721SignedOrder.maker
+    );
+    expect(makerBalance.gt(0)).toBe(true);
+
+    const makerApprovalStatus = await nftSwapperMaker.loadApprovalStatus(
+      makerAsset,
+      v4Erc721SignedOrder.maker
+    );
+    expect(makerApprovalStatus.contractApproved).toBe(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5632,10 +5632,10 @@ prettier@^2.3.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
   integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
-prettier@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
-  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"


### PR DESCRIPTION
Sharing useful logic on how to validate orders since this exists on the API side.

Basically check either (or both) the maker and taker assets for:
a) wallet has sufficient balance 
b) asset being traded is approved 0x v4 exchange proxy contract (everything except ETH requires approval*)

*unless using super secret `fillBuyNftOrderWithoutApproval` function, then you don't need to approve your NFT to accept a bid on it lol