### PR TITLE
Add Ubiq support to 0x v4. Chain ID 8

### DIFF
--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -73,6 +73,7 @@ import { arrayify } from '@ethersproject/bytes';
 export enum SupportedChainIdsV4 {
   Mainnet = 1,
   Ropsten = 3,
+  Ubiq = 8,
   Ganache = 1337,
   Polygon = 137,
   PolygonMumbai = 80001,

--- a/src/sdk/v4/addresses.json
+++ b/src/sdk/v4/addresses.json
@@ -11,6 +11,10 @@
     "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
     "wrappedNativeToken": "0xc778417e063141139fce010982780140aa0cd5ab"
   },
+  "8": {
+    "exchange": "0x19aaD856cE8c4C7e813233b21d56dA97796cC052",
+    "wrappedNativeToken": "0x1FA6A37c64804C0D797bA6bC1955E50068FbF362"
+  },
   "10": {
     "exchange": "0xdef1abe32c034e558cdd535791643c58a13acc10",
     "wrappedNativeToken": "0x4200000000000000000000000000000000000006"


### PR DESCRIPTION
Deployed and configured the following.

```
deploying "InitialMigration" (tx: 0x67ae19bfa08cc0328e1b9d8a5488cf8ef0997aa9de27dd477c3cd10c38aaa120)...: deployed at 0x5b957E61FF15863c29B69da1c1172baBB044c728 with 620174 gas
deploying "ZeroEx" (tx: 0xa124fd7dbb970e4aa849a69b710103cac00a85830052e9d6937678ab663e5503)...: deployed at 0x19aaD856cE8c4C7e813233b21d56dA97796cC052 with 755195 gas
deploying "ERC721OrdersFeature" (tx: 0x7d66b56f180a5c664e027a8e623820463d568fdcaac6db3f2396b182989c9ddf)...: deployed at 0x7AE76139C07099FD77F5100af73871ec367Ca808 with 4728224 gas
deploying "ERC1155OrdersFeature" (tx: 0x44e098dbc98c4295526de1064ace1c7a557100ac52f0b98824ef01c488404f6f)...: deployed at 0x5e850FC7104d1843957627c5028020faB1fd09dD with 4313656 gas
deploying "OtcOrdersFeature" (tx: 0x622222b8c1e23181ed8672501c3dec941abf8c85095a724e6373ea7253beacf9)...: deployed at 0x27548434B9b5dF3EF60fb1ec289CaABBA6B4fe2A with 2524104 gas
deploying "ERC165Feature" (tx: 0x53f1151d456cbdc1e957babda3952105096e537015a19d4efb8d8c52464b6774)...: deployed at 0x71d56d94261086bFfa3D5f97c2043cD7E1a87afb with 210133 gas
deploying "SimpleFunctionRegistryFeature" (tx: 0x50976cb462af877eaf96a6e1eb1bec7ae6d96e22d7ff4091c5673eb481b89e74)...: deployed at 0xC1Ab827a823d17D9db77fdF4D61809F0391B9050 with 773300 gas
deploying "OwnableFeature" (tx: 0x42eb9017396e78baccec288b68a8c444ab5632ec0d216762d511d92fa88e0270)...: deployed at 0x3956FB6BDFcb81c12b3B965DEC05B4012f4Be6DD with 758315 gas

executing InitialMigration.initializeZeroEx (tx: 0x1568e6e62c8d2d7662d33def2f1677281ad0b87b56e057aeaf6204bd7436600a) ...: performed with 445304 gas
executing ERC165Feature extend (tx: 0x376aeeab485ad5ee1e7de6109c6218aea370dcf7f4520501878248a0a6881091)
executing ERC721OrdersFeature migrate (tx: 0x83223933804071f3bdbc942740373221a28f896426cf0fcf1ed40a2d908b41c1)
executing ERC1155OrdersFeature migrate (tx: 0x88a4a6933104274f8ba5a3830fc3cb500106d1f8f844d207bdb801dc389468ef)
executing OtcOrdersFeature migrate (tx: 0xaacb1d507a6e1a426f50a275ce6da09b038bd7c942066a736122c33cadbe643d)
```

Waiting for https://sourcify.dev to be up to Verify the contract source there.

Thanks!
