### PR TITLE
feat: custom approval amounts for ERC20 tokens

### DIFF
--- a/src/sdk/v4/types.ts
+++ b/src/sdk/v4/types.ts
@@ -186,6 +186,7 @@ export interface ApprovalOverrides {
   approvalOnlyTokenIdIfErc721: boolean;
   exchangeContractAddress: string;
   chainId: number;
+  approvalAmount: BigNumberish;
 }
 
 export interface FillOrderOverrides {


### PR DESCRIPTION
Adds support for custom approval amounts for ERC20 tokens, instead of assuming max approvals. Default behavior is still max approvals for backwards compatibility until v2 breaking changes, then we will be only approving required amounts by default.