### PR TITLE
feat: custom approval amounts for ERC20 tokens in V3

### DIFF
--- a/src/sdk/v3/INftSwapV3.ts
+++ b/src/sdk/v3/INftSwapV3.ts
@@ -2,6 +2,7 @@ import type { TransactionReceipt } from '@ethersproject/providers';
 import type { ContractTransaction } from '@ethersproject/contracts';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type {
+  BigNumberish,
   Order,
   OrderInfoV3,
   OrderStatusV3,
@@ -119,6 +120,7 @@ export interface ApprovalOverrides {
   exchangeProxyContractAddressForAsset: string;
   chainId: number;
   gasAmountBufferMultiple: number | null;
+  approvalAmount: BigNumberish
 }
 
 export interface FillOrderOverrides {

--- a/src/sdk/v3/NftSwapV3.ts
+++ b/src/sdk/v3/NftSwapV3.ts
@@ -285,7 +285,8 @@ class NftSwapV3 implements INftSwapV3 {
 
   public loadApprovalStatus = async (
     asset: SwappableAsset,
-    walletAddress: string
+    walletAddress: string,
+    approvalOverrides?: Partial<ApprovalOverrides> | undefined
   ) => {
     // TODO(johnrjj) - Fix this...
     const exchangeProxyAddressForAsset = getProxyAddressForErcType(
@@ -297,7 +298,8 @@ class NftSwapV3 implements INftSwapV3 {
       walletAddress,
       exchangeProxyAddressForAsset,
       assetInternalFmt,
-      this.provider
+      this.provider,
+      approvalOverrides?.approvalAmount
     );
   };
 


### PR DESCRIPTION
Ports the changes made in V4 for custom ERC20 approval amounts into the V3 SDK.

V4 changes referenced
https://github.com/trader-xyz/nft-swap-sdk/pull/103

Tested this within my own project and its working as expected.