### PR TITLE
feat: add Sepolia Testnet to NFT Swap SDK

### DIFF
--- a/src/sdk/v4/NftSwapV4.ts
+++ b/src/sdk/v4/NftSwapV4.ts
@@ -87,6 +87,7 @@ export enum SupportedChainIdsV4 {
   Arbitrum = 42161,
   Base = 8453,
   BaseGoerli = 84531,
+  Sepolia = 11155111,
 }
 
 export const SupportedChainsForV4OrderbookStatusMonitoring = [

--- a/src/sdk/v4/addresses.json
+++ b/src/sdk/v4/addresses.json
@@ -66,5 +66,9 @@
   "84531": {
     "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
     "wrappedNativeToken": "0x4200000000000000000000000000000000000006"
+  },
+  "11155111": {
+    "exchange": "0xdef1c0ded9bec7f1a1670819833240f027b25eff",
+    "wrappedNativeToken": "0xfff9976782d46cc05630d1f6ebab18b2324d6b14"
   }
 }


### PR DESCRIPTION
Noticed that Sepolia was missing from SDK, so figured I would add it. Based my changes off of commit b1e709ef3ceac81a9418804b0b432065dfa5b5d5 (feat: adds Base and Base Goerli Testnet to NFT Swap SDK). Thanks!